### PR TITLE
no-constructor-attributes: introduce global property/attr detection

### DIFF
--- a/src/rules/no-constructor-attributes.ts
+++ b/src/rules/no-constructor-attributes.ts
@@ -47,12 +47,31 @@ const rule: Rule.RuleModule = {
       'toggleAttribute'
     ];
     const bannedMembers = [
+      // Child node inspection
       'innerHTML',
       'children',
       'childNodes',
       'firstChild',
       'lastChild',
-      'attributes'
+      'attributes',
+      // Global reflected attributes
+      'accessKey',
+      'autocapitalize',
+      'className',
+      'classList',
+      'contentEditable',
+      'dataset',
+      'dir',
+      'draggable',
+      'hidden',
+      'id',
+      'lang',
+      'slot',
+      'spellcheck',
+      'style',
+      'tabIndex',
+      'title',
+      'translate'
     ];
     const source = context.getSourceCode();
 

--- a/src/test/rules/no-constructor-attributes_test.ts
+++ b/src/test/rules/no-constructor-attributes_test.ts
@@ -59,6 +59,74 @@ ruleTester.run('no-constructor-attributes', rule, {
     {
       code: `class Foo extends HTMLElement {
         constructor() {
+          this.accessKey = 'z';
+          this.autocapitalize = 'on';
+          this.className = 'foo';
+          this.contentEditable = 'true';
+          this.dir = 'rtl';
+          this.draggable = 'true';
+          this.hidden = 'true';
+          this.id = 'foo';
+          this.lang = 'foo';
+          this.slot = 'foo';
+          this.spellcheck = 'true';
+          this.style = 'color: blue';
+          this.tabIndex = 42;
+          this.title = 'foo';
+          this.translate = 'true';
+        }
+      }`,
+      errors: [
+        { messageId: 'constructorAttrs', line: 3, column: 11 },
+        { messageId: 'constructorAttrs', line: 4, column: 11 },
+        { messageId: 'constructorAttrs', line: 5, column: 11 },
+        { messageId: 'constructorAttrs', line: 6, column: 11 },
+        { messageId: 'constructorAttrs', line: 7, column: 11 },
+        { messageId: 'constructorAttrs', line: 8, column: 11 },
+        { messageId: 'constructorAttrs', line: 9, column: 11 },
+        { messageId: 'constructorAttrs', line: 10, column: 11 },
+        { messageId: 'constructorAttrs', line: 11, column: 11 },
+        { messageId: 'constructorAttrs', line: 12, column: 11 },
+        { messageId: 'constructorAttrs', line: 13, column: 11 },
+        { messageId: 'constructorAttrs', line: 14, column: 11 },
+        { messageId: 'constructorAttrs', line: 15, column: 11 },
+        { messageId: 'constructorAttrs', line: 16, column: 11 },
+        { messageId: 'constructorAttrs', line: 17, column: 11 }
+      ]
+    },
+    {
+      code: `class Foo extends HTMLElement {
+        constructor() {
+          this.classList.toggle('foo');
+          this.classList.add('foo');
+          this.classList.remove('foo');
+          const foo = this.classList;
+        }
+      }`,
+      errors: [
+        { messageId: 'constructorAttrs', line: 3, column: 11 },
+        { messageId: 'constructorAttrs', line: 4, column: 11 },
+        { messageId: 'constructorAttrs', line: 5, column: 11 },
+        { messageId: 'constructorAttrs', line: 6, column: 23 }
+      ]
+    },
+    {
+      code: `class Foo extends HTMLElement {
+        constructor() {
+          this.dataset['foo'] = 'bar';
+          const foo = this.dataset['foo'];
+          const bar = this.dataset;
+        }
+      }`,
+      errors: [
+        { messageId: 'constructorAttrs', line: 3, column: 11 },
+        { messageId: 'constructorAttrs', line: 4, column: 23 },
+        { messageId: 'constructorAttrs', line: 5, column: 23 }
+      ]
+    },
+    {
+      code: `class Foo extends HTMLElement {
+        constructor() {
           this.hasAttribute('foo');
           this.getAttribute('foo');
           this.hasAttributes();

--- a/src/test/rules/no-constructor-attributes_test.ts
+++ b/src/test/rules/no-constructor-attributes_test.ts
@@ -77,21 +77,21 @@ ruleTester.run('no-constructor-attributes', rule, {
         }
       }`,
       errors: [
-        { messageId: 'constructorAttrs', line: 3, column: 11 },
-        { messageId: 'constructorAttrs', line: 4, column: 11 },
-        { messageId: 'constructorAttrs', line: 5, column: 11 },
-        { messageId: 'constructorAttrs', line: 6, column: 11 },
-        { messageId: 'constructorAttrs', line: 7, column: 11 },
-        { messageId: 'constructorAttrs', line: 8, column: 11 },
-        { messageId: 'constructorAttrs', line: 9, column: 11 },
-        { messageId: 'constructorAttrs', line: 10, column: 11 },
-        { messageId: 'constructorAttrs', line: 11, column: 11 },
-        { messageId: 'constructorAttrs', line: 12, column: 11 },
-        { messageId: 'constructorAttrs', line: 13, column: 11 },
-        { messageId: 'constructorAttrs', line: 14, column: 11 },
-        { messageId: 'constructorAttrs', line: 15, column: 11 },
-        { messageId: 'constructorAttrs', line: 16, column: 11 },
-        { messageId: 'constructorAttrs', line: 17, column: 11 }
+        {messageId: 'constructorAttrs', line: 3, column: 11},
+        {messageId: 'constructorAttrs', line: 4, column: 11},
+        {messageId: 'constructorAttrs', line: 5, column: 11},
+        {messageId: 'constructorAttrs', line: 6, column: 11},
+        {messageId: 'constructorAttrs', line: 7, column: 11},
+        {messageId: 'constructorAttrs', line: 8, column: 11},
+        {messageId: 'constructorAttrs', line: 9, column: 11},
+        {messageId: 'constructorAttrs', line: 10, column: 11},
+        {messageId: 'constructorAttrs', line: 11, column: 11},
+        {messageId: 'constructorAttrs', line: 12, column: 11},
+        {messageId: 'constructorAttrs', line: 13, column: 11},
+        {messageId: 'constructorAttrs', line: 14, column: 11},
+        {messageId: 'constructorAttrs', line: 15, column: 11},
+        {messageId: 'constructorAttrs', line: 16, column: 11},
+        {messageId: 'constructorAttrs', line: 17, column: 11}
       ]
     },
     {
@@ -104,10 +104,10 @@ ruleTester.run('no-constructor-attributes', rule, {
         }
       }`,
       errors: [
-        { messageId: 'constructorAttrs', line: 3, column: 11 },
-        { messageId: 'constructorAttrs', line: 4, column: 11 },
-        { messageId: 'constructorAttrs', line: 5, column: 11 },
-        { messageId: 'constructorAttrs', line: 6, column: 23 }
+        {messageId: 'constructorAttrs', line: 3, column: 11},
+        {messageId: 'constructorAttrs', line: 4, column: 11},
+        {messageId: 'constructorAttrs', line: 5, column: 11},
+        {messageId: 'constructorAttrs', line: 6, column: 23}
       ]
     },
     {
@@ -119,9 +119,9 @@ ruleTester.run('no-constructor-attributes', rule, {
         }
       }`,
       errors: [
-        { messageId: 'constructorAttrs', line: 3, column: 11 },
-        { messageId: 'constructorAttrs', line: 4, column: 23 },
-        { messageId: 'constructorAttrs', line: 5, column: 23 }
+        {messageId: 'constructorAttrs', line: 3, column: 11},
+        {messageId: 'constructorAttrs', line: 4, column: 23},
+        {messageId: 'constructorAttrs', line: 5, column: 23}
       ]
     },
     {


### PR DESCRIPTION
This introduces some global properties to the banned members list as they are reflected by default/globally.

For example, `this.id = 'foo'` will reflect to the `id` attribute (thus breaking the custom element rules and causing an exception).