### PR TITLE
support detection of custom element classes through define calls

### DIFF
--- a/src/rules/no-constructor-attributes.ts
+++ b/src/rules/no-constructor-attributes.ts
@@ -5,7 +5,7 @@
 
 import {Rule} from 'eslint';
 import * as ESTree from 'estree';
-import {isCustomElement} from '../util';
+import {isCustomElement, getDefineCallName, getParentNode} from '../util';
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -27,8 +27,6 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     // variables should be defined here
-    let insideConstructor = false;
-    let insideElement = false;
     const bannedCallExpressions = [
       'append',
       'appendChild',
@@ -74,6 +72,8 @@ const rule: Rule.RuleModule = {
       'translate'
     ];
     const source = context.getSourceCode();
+    const scannedMembers = new Set<ESTree.Node>();
+    const scannedDefinitions = new Set<string>();
 
     //----------------------------------------------------------------------
     // Helpers
@@ -135,49 +135,64 @@ const rule: Rule.RuleModule = {
     //----------------------------------------------------------------------
 
     return {
-      'ClassDeclaration,ClassExpression': (node: ESTree.Node): void => {
-        if (
-          (node.type === 'ClassExpression' ||
-            node.type === 'ClassDeclaration') &&
-          isCustomElement(node, source.getJSDocComment(node))
-        ) {
-          insideElement = true;
-        }
-      },
-      'ClassDeclaration,ClassExpression:exit': (): void => {
-        insideElement = false;
-      },
-      MethodDefinition: (node: ESTree.Node): void => {
-        if (
-          insideElement &&
-          node.type === 'MethodDefinition' &&
-          node.kind === 'constructor' &&
-          node.static === false &&
-          node.key.type === 'Identifier' &&
-          node.key.name === 'constructor'
-        ) {
-          insideConstructor = true;
-        }
-      },
-      'MethodDefinition:exit': (): void => {
-        insideConstructor = false;
-      },
       CallExpression: (node: ESTree.Node): void => {
-        if (
-          insideConstructor &&
-          node.type === 'CallExpression' &&
-          isBannedCallExpr(node)
-        ) {
-          context.report({node: node, messageId: 'constructorAttrs'});
+        if (node.type === 'CallExpression') {
+          const parent = getParentNode<ESTree.MethodDefinition>(node, [
+            'MethodDefinition'
+          ]);
+
+          if (
+            parent !== undefined &&
+            parent.kind === 'constructor' &&
+            parent.static === false &&
+            parent.key.type === 'Identifier' &&
+            parent.key.name === 'constructor' &&
+            isBannedCallExpr(node)
+          ) {
+            scannedMembers.add(node);
+          }
+
+          const definedName = getDefineCallName(node);
+
+          if (definedName !== undefined) {
+            scannedDefinitions.add(definedName);
+          }
         }
       },
       MemberExpression: (node: ESTree.Node): void => {
+        const parent = getParentNode<ESTree.MethodDefinition>(node, [
+          'MethodDefinition'
+        ]);
+
         if (
-          insideConstructor &&
           node.type === 'MemberExpression' &&
+          parent !== undefined &&
+          parent.kind === 'constructor' &&
+          parent.static === false &&
+          parent.key.type === 'Identifier' &&
+          parent.key.name === 'constructor' &&
           isBannedMember(node)
         ) {
-          context.report({node: node, messageId: 'constructorAttrs'});
+          scannedMembers.add(node);
+        }
+      },
+      'Program:exit': (): void => {
+        for (const member of scannedMembers) {
+          const parent = getParentNode<ESTree.Class>(member, [
+            'ClassDeclaration',
+            'ClassExpression'
+          ]);
+
+          if (
+            parent !== undefined &&
+            (isCustomElement(parent, source.getJSDocComment(parent)) ||
+              (parent.id !== undefined &&
+                parent.id !== null &&
+                parent.id.type === 'Identifier' &&
+                scannedDefinitions.has(parent.id.name)))
+          ) {
+            context.report({node: member, messageId: 'constructorAttrs'});
+          }
         }
       }
     };

--- a/src/test/rules/attach-shadow-constructor_test.ts
+++ b/src/test/rules/attach-shadow-constructor_test.ts
@@ -149,6 +149,21 @@ ruleTester.run('attach-shadow-constructor', rule, {
           column: 11
         }
       ]
+    },
+    {
+      code: `class A extends Element {
+        connectedCallback() {
+          this.attachShadow();
+        }
+      }
+      customElements.define('foo-bar', A);`,
+      errors: [
+        {
+          messageId: 'attachShadowConstructor',
+          line: 3,
+          column: 11
+        }
+      ]
     }
   ]
 });

--- a/src/test/rules/guard-super-call_test.ts
+++ b/src/test/rules/guard-super-call_test.ts
@@ -153,6 +153,21 @@ ruleTester.run('guard-super-call', rule, {
           column: 11
         }
       ]
+    },
+    {
+      code: `class A extends B {
+        connectedCallback() {
+          super.connectedCallback();
+        }
+      }
+      customElements.define('foo-bar', A);`,
+      errors: [
+        {
+          messageId: 'guardSuperCall',
+          line: 3,
+          column: 11
+        }
+      ]
     }
   ]
 });

--- a/src/test/rules/no-constructor-attributes_test.ts
+++ b/src/test/rules/no-constructor-attributes_test.ts
@@ -507,6 +507,42 @@ ruleTester.run('no-constructor-attributes', rule, {
       ]
     },
     {
+      code: `class Foo extends Bar {
+        constructor() {
+          super();
+          this.setAttribute('x', 'y');
+        }
+      }
+      customElements.define('x', Foo);`,
+      errors: [
+        {
+          message:
+            'Attributes must not be interacted with in the ' +
+            'constructor as the element may not be ready yet.',
+          line: 4,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `customElements.define('x', Foo);
+      class Foo extends Bar {
+        constructor() {
+          super();
+          this.setAttribute('x', 'y');
+        }
+      }`,
+      errors: [
+        {
+          message:
+            'Attributes must not be interacted with in the ' +
+            'constructor as the element may not be ready yet.',
+          line: 5,
+          column: 11
+        }
+      ]
+    },
+    {
       code: `@customElement('x-foo')
       class Foo extends Bar {
         constructor() {

--- a/src/test/rules/no-self-class_test.ts
+++ b/src/test/rules/no-self-class_test.ts
@@ -225,6 +225,21 @@ ruleTester.run('no-self-class', rule, {
           column: 11
         }
       ]
+    },
+    {
+      code: `class Foo extends Bar {
+        method() {
+          this.className += 'test';
+        }
+      }
+      customElements.define('foo-bar', Foo);`,
+      errors: [
+        {
+          messageId: 'selfClass',
+          line: 3,
+          column: 11
+        }
+      ]
     }
   ]
 });

--- a/src/test/rules/no-typos_test.ts
+++ b/src/test/rules/no-typos_test.ts
@@ -192,6 +192,22 @@ ruleTester.run('no-typos', rule, {
           column: 22
         }
       ]
+    },
+    {
+      code: `class Foo extends Bar {
+          static get observedAtributes() {}
+        }
+      customElements.define('foo-bar', Foo);`,
+      errors: [
+        {
+          messageId: 'member',
+          data: {
+            replacement: 'observedAttributes'
+          },
+          line: 2,
+          column: 22
+        }
+      ]
     }
   ]
 });


### PR DESCRIPTION
This adds support for custom element classes being detected by the fact their identifier is used in a `customElements.define` call.

Not entirely sure about it yet so will publish a new version and keep this open a few days.