### PR TITLE
fix: false positive when accessing shadow dom in constructor

### DIFF
--- a/docs/rules/no-constructor-attributes.md
+++ b/docs/rules/no-constructor-attributes.md
@@ -1,9 +1,10 @@
 # Disallows interaction with attributes in constructors (no-constructor-attributes)
 
-Constructors of custom elements should never interact with their own light DOM and attributes as the element will not be connected to the DOM when created programmatically (i.e. using `document.createElement()`).
+Constructors of custom elements should never interact with the DOM or
+attributes as the element may not yet be upgraded.
 
-> Do note that interaction with the element's shadow DOM is perfectly valid at this point as it does not interfere with
-> the DOM tree of the consumer.
+> Do note that interaction with the element's shadow DOM is perfectly valid at
+> this point as it does not interfere with the DOM tree of the consumer.
 
 More information on why this is a bad thing can be found in the HTML
 standard [here](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance).

--- a/docs/rules/no-constructor-attributes.md
+++ b/docs/rules/no-constructor-attributes.md
@@ -1,21 +1,30 @@
 # Disallows interaction with attributes in constructors (no-constructor-attributes)
 
-Constructors of custom elements should never interact with the DOM or
-attributes as the element may not yet be upgraded.
+Constructors of custom elements should never interact with their own light DOM and attributes as the element will not be connected to the DOM when created programmatically (i.e. using `document.createElement()`).
+
+> Do note that interaction with the element's shadow DOM is perfectly valid at this point as it does not interfere with
+> the DOM tree of the consumer.
 
 More information on why this is a bad thing can be found in the HTML
 standard [here](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance).
 
 ## Rule Details
 
-This rule disallows interaction with the DOM inside element constructors.
+This rule disallows interaction with the light DOM inside element constructors.
 
 The following patterns are considered warnings:
 
 ```ts
-class MyElement extends HTMLElement {
+class MyCustomElement extends HTMLElement {
   constructor() {
     this.setAttribute('foo', 'bar');
+  }
+}
+
+class AnotherCustomElement extends HTMLElement {
+  constructor() {
+    const el = document.createElement('div');
+    this.append(el);
   }
 }
 ```
@@ -23,15 +32,30 @@ class MyElement extends HTMLElement {
 The following patterns are not warnings:
 
 ```ts
-class MyClass {
-  myMethod() {
+class NotACustomElement {
+  constructor() {
     this.setAttribute('foo', 'bar');
   }
 }
 
-class OtherClass {
-  constructor() {
+class MyCustomElement extends HTMLElement {
+  connectedCallback() {
     this.setAttribute('foo', 'bar');
+  }
+}
+
+class AnotherCustomElement extends HTMLElement {
+  connectedCallback() {
+    const el = document.createElement('div');
+    this.append(el);
+  }
+}
+
+class CustomElementWithShadowDOM extends HTMLElement {
+  constructor() {
+    this.attachShadow({mode: 'open'});
+    const el = document.createElement('div');
+    this.shadowRoot.append(el);
   }
 }
 ```

--- a/src/rules/no-constructor-attributes.ts
+++ b/src/rules/no-constructor-attributes.ts
@@ -81,7 +81,7 @@ const rule: Rule.RuleModule = {
     /**
      * Determines if a call expression is banned or not.
      * This is true if it is in the banned list and has been called
-     * on `this` or `this.shadowRoot`, or if it is a `document.write`
+     * on `this`, or if it is a `document.write`
      * or `document.open`.
      *
      * @param {ESTree.CallExpression} node Node to test
@@ -93,12 +93,6 @@ const rule: Rule.RuleModule = {
         ((node.callee.object.type === 'ThisExpression' &&
           node.callee.property.type === 'Identifier' &&
           bannedCallExpressions.includes(node.callee.property.name)) ||
-          (node.callee.object.type === 'MemberExpression' &&
-            node.callee.object.object.type === 'ThisExpression' &&
-            node.callee.object.property.type === 'Identifier' &&
-            node.callee.object.property.name === 'shadowRoot' &&
-            node.callee.property.type === 'Identifier' &&
-            bannedCallExpressions.includes(node.callee.property.name)) ||
           (node.callee.object.type === 'Identifier' &&
             node.callee.object.name === 'document' &&
             node.callee.property.type === 'Identifier' &&
@@ -118,15 +112,9 @@ const rule: Rule.RuleModule = {
      */
     function isBannedMember(node: ESTree.MemberExpression): boolean {
       return (
-        (node.object.type === 'ThisExpression' &&
-          node.property.type === 'Identifier' &&
-          bannedMembers.includes(node.property.name)) ||
-        (node.object.type === 'MemberExpression' &&
-          node.object.object.type === 'ThisExpression' &&
-          node.object.property.type === 'Identifier' &&
-          node.object.property.name === 'shadowRoot' &&
-          node.property.type === 'Identifier' &&
-          bannedMembers.includes(node.property.name))
+        node.object.type === 'ThisExpression' &&
+        node.property.type === 'Identifier' &&
+        bannedMembers.includes(node.property.name)
       );
     }
 

--- a/src/test/rules/no-constructor-attributes_test.ts
+++ b/src/test/rules/no-constructor-attributes_test.ts
@@ -59,13 +59,13 @@ ruleTester.run('no-constructor-attributes', rule, {
     {
       code: `class Foo extends HTMLElement {
         constructor() {
-          this.shadowRoot.hasAttribute('foo');
-          this.shadowRoot.getAttribute('foo');
-          this.shadowRoot.hasAttributes();
-          this.shadowRoot.removeAttribute('foo');
-          this.shadowRoot.setAttribute('foo', 'bar');
-          this.shadowRoot.toggleAttribute('foo');
-          console.log(this.shadowRoot.attributes[0]);
+          this.shadowRoot.firstElementChild.hasAttribute('foo');
+          this.shadowRoot.firstElementChild.getAttribute('foo');
+          this.shadowRoot.firstElementChild.hasAttributes();
+          this.shadowRoot.firstElementChild.removeAttribute('foo');
+          this.shadowRoot.firstElementChild.setAttribute('foo', 'bar');
+          this.shadowRoot.firstElementChild.toggleAttribute('foo');
+          console.log(this.shadowRoot.firstElementChild.attributes[0]);
         }
       }`
     },

--- a/src/test/rules/no-constructor-attributes_test.ts
+++ b/src/test/rules/no-constructor-attributes_test.ts
@@ -55,6 +55,58 @@ ruleTester.run('no-constructor-attributes', rule, {
       code: `class NonElement {
       constructor() { this.getAttribute('x'); this.appendChild(c); }
     }`
+    },
+    {
+      code: `class Foo extends HTMLElement {
+        constructor() {
+          this.shadowRoot.hasAttribute('foo');
+          this.shadowRoot.getAttribute('foo');
+          this.shadowRoot.hasAttributes();
+          this.shadowRoot.removeAttribute('foo');
+          this.shadowRoot.setAttribute('foo', 'bar');
+          this.shadowRoot.toggleAttribute('foo');
+          console.log(this.shadowRoot.attributes[0]);
+        }
+      }`
+    },
+    {
+      code: `class Foo extends HTMLElement {
+        constructor() {
+          this.shadowRoot.innerHTML += 'test';
+          this.shadowRoot.innerHTML = 'test';
+        }
+      }`
+    },
+    {
+      code: `class Foo extends HTMLElement {
+        constructor() {
+          this.shadowRoot.childNodes[0];
+          const x = this.shadowRoot.firstChild;
+          this.shadowRoot.lastChild.innerHTML = 'foo';
+          const y = [...this.shadowRoot.children];
+        }
+      }`
+    },
+    {
+      code: `class Foo extends HTMLElement {
+        constructor() {
+          this.shadowRoot.getElementsByClassName(foo)
+          this.shadowRoot.getElementsByTagName(foo)
+          this.shadowRoot.querySelector(foo)
+          this.shadowRoot.querySelectorAll(foo)
+        }
+      }`
+    },
+    {
+      code: `class Foo extends HTMLElement {
+        constructor() {
+          this.shadowRoot.append(node);
+          this.shadowRoot.appendChild(node);
+          this.shadowRoot.removeChild(node);
+          this.shadowRoot.replaceChild(a, b);
+          this.shadowRoot.insertBefore(a, b)
+        }
+      }`
     }
   ],
 
@@ -180,56 +232,6 @@ ruleTester.run('no-constructor-attributes', rule, {
     {
       code: `class Foo extends HTMLElement {
         constructor() {
-          this.shadowRoot.hasAttribute('foo');
-          this.shadowRoot.getAttribute('foo');
-          this.shadowRoot.hasAttributes();
-          this.shadowRoot.removeAttribute('foo');
-          this.shadowRoot.setAttribute('foo', 'bar');
-          this.shadowRoot.toggleAttribute('foo');
-          console.log(this.shadowRoot.attributes[0]);
-        }
-      }`,
-      errors: [
-        {
-          messageId: 'constructorAttrs',
-          line: 3,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 4,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 5,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 6,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 7,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 8,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 9,
-          column: 23
-        }
-      ]
-    },
-    {
-      code: `class Foo extends HTMLElement {
-        constructor() {
           document.write('test');
           document.open(url);
         }
@@ -270,69 +272,11 @@ ruleTester.run('no-constructor-attributes', rule, {
     {
       code: `class Foo extends HTMLElement {
         constructor() {
-          this.shadowRoot.innerHTML += 'test';
-          this.shadowRoot.innerHTML = 'test';
-        }
-      }`,
-      errors: [
-        {
-          messageId: 'constructorAttrs',
-          line: 3,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 4,
-          column: 11
-        }
-      ]
-    },
-    {
-      code: `class Foo extends HTMLElement {
-        constructor() {
           this.append(node);
           this.appendChild(node);
           this.removeChild(node);
           this.replaceChild(a, b);
           this.insertBefore(a, b)
-        }
-      }`,
-      errors: [
-        {
-          messageId: 'constructorAttrs',
-          line: 3,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 4,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 5,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 6,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 7,
-          column: 11
-        }
-      ]
-    },
-    {
-      code: `class Foo extends HTMLElement {
-        constructor() {
-          this.shadowRoot.append(node);
-          this.shadowRoot.appendChild(node);
-          this.shadowRoot.removeChild(node);
-          this.shadowRoot.replaceChild(a, b);
-          this.shadowRoot.insertBefore(a, b)
         }
       }`,
       errors: [
@@ -395,38 +339,7 @@ ruleTester.run('no-constructor-attributes', rule, {
         }
       ]
     },
-    {
-      code: `class Foo extends HTMLElement {
-        constructor() {
-          this.shadowRoot.childNodes[0];
-          const x = this.shadowRoot.firstChild;
-          this.shadowRoot.lastChild.innerHTML = 'foo';
-          const y = [...this.shadowRoot.children];
-        }
-      }`,
-      errors: [
-        {
-          messageId: 'constructorAttrs',
-          line: 3,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 4,
-          column: 21
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 5,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 6,
-          column: 25
-        }
-      ]
-    },
+
     {
       code: `class Foo extends HTMLElement {
         constructor() {
@@ -434,38 +347,6 @@ ruleTester.run('no-constructor-attributes', rule, {
           this.getElementsByTagName(foo)
           this.querySelector(foo)
           this.querySelectorAll(foo)
-        }
-      }`,
-      errors: [
-        {
-          messageId: 'constructorAttrs',
-          line: 3,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 4,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 5,
-          column: 11
-        },
-        {
-          messageId: 'constructorAttrs',
-          line: 6,
-          column: 11
-        }
-      ]
-    },
-    {
-      code: `class Foo extends HTMLElement {
-        constructor() {
-          this.shadowRoot.getElementsByClassName(foo)
-          this.shadowRoot.getElementsByTagName(foo)
-          this.shadowRoot.querySelector(foo)
-          this.shadowRoot.querySelectorAll(foo)
         }
       }`,
       errors: [


### PR DESCRIPTION
Fix #46

## Explainer

A custom element instance can be created programmatically with `document.createElement`. Which means the class constructor may be called **before** the element has access to the DOM. This is why we can't modify the element itself in the constructor, including its light dom.

Yet, a shadow DOM is created _"inside"_ the element and doesn't need to wait until this element is attached to another DOM to be available. Therefore, no error will occur when accessing the shadowRoot inside a custom element constructor.

Actually, this is even the recommended approach, as it will allow building the Web Component "content" ahead of time (which may lead to better performance), in a 100% controlled environment (which may avoid some bugs).

## Quote from the [HTML Standard](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance)

- The element must not gain any attributes or children, as this violates the expectations of consumers who use the createElement or createElementNS methods.
- In general, work should be deferred to connectedCallback as much as possible—especially work involving fetching resources or rendering. ***However, note that connectedCallback can be called more than once, so any initialization work that is truly one-time will need a guard to prevent it from running twice.***
- In general, ***the constructor should be used to set up initial state*** and default values, and to set up event listeners ***and possibly a shadow root***.