### PR TITLE
Remove redundant checks

### DIFF
--- a/src/rules/attach-shadow-constructor.ts
+++ b/src/rules/attach-shadow-constructor.ts
@@ -39,22 +39,17 @@ const rule: Rule.RuleModule = {
     //----------------------------------------------------------------------
 
     return {
-      'ClassDeclaration,ClassExpression': (node: ESTree.Node): void => {
-        if (
-          (node.type === 'ClassExpression' ||
-            node.type === 'ClassDeclaration') &&
-          isCustomElement(context, node, source.getJSDocComment(node))
-        ) {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (isCustomElement(context, node, source.getJSDocComment(node))) {
           insideElement = true;
         }
       },
       'ClassDeclaration,ClassExpression:exit': (): void => {
         insideElement = false;
       },
-      MethodDefinition: (node: ESTree.Node): void => {
+      MethodDefinition: (node: ESTree.MethodDefinition): void => {
         if (
           insideElement &&
-          node.type === 'MethodDefinition' &&
           node.kind !== 'constructor' &&
           node.key.type === 'Identifier' &&
           node.key.name !== 'constructor'
@@ -65,10 +60,9 @@ const rule: Rule.RuleModule = {
       'MethodDefinition:exit': (): void => {
         insideNonConstructor = false;
       },
-      CallExpression: (node: ESTree.Node): void => {
+      CallExpression: (node: ESTree.CallExpression): void => {
         if (
           insideNonConstructor &&
-          node.type === 'CallExpression' &&
           node.callee.type === 'MemberExpression' &&
           node.callee.object.type === 'ThisExpression' &&
           node.callee.property.type === 'Identifier' &&

--- a/src/rules/guard-super-call.ts
+++ b/src/rules/guard-super-call.ts
@@ -118,10 +118,8 @@ const rule: Rule.RuleModule = {
     //----------------------------------------------------------------------
 
     return {
-      'ClassDeclaration,ClassExpression': (node: ESTree.Node): void => {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
         if (
-          (node.type === 'ClassExpression' ||
-            node.type === 'ClassDeclaration') &&
           isCustomElement(context, node, source.getJSDocComment(node)) &&
           !isNativeCustomElement(node)
         ) {
@@ -131,7 +129,7 @@ const rule: Rule.RuleModule = {
       'ClassDeclaration,ClassExpression:exit': (): void => {
         insideNonNativeElement = false;
       },
-      MethodDefinition: (node: ESTree.Node): void => {
+      MethodDefinition: (node: ESTree.MethodDefinition): void => {
         if (!insideNonNativeElement || !isLifecycleHook(node)) {
           return;
         }

--- a/src/rules/no-closed-shadow-root.ts
+++ b/src/rules/no-closed-shadow-root.ts
@@ -60,9 +60,8 @@ const rule: Rule.RuleModule = {
     //----------------------------------------------------------------------
 
     return {
-      CallExpression: (node: ESTree.Node): void => {
+      CallExpression: (node: ESTree.CallExpression): void => {
         if (
-          node.type === 'CallExpression' &&
           node.callee.type === 'MemberExpression' &&
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'attachShadow'

--- a/src/rules/no-constructor-attributes.ts
+++ b/src/rules/no-constructor-attributes.ts
@@ -123,22 +123,17 @@ const rule: Rule.RuleModule = {
     //----------------------------------------------------------------------
 
     return {
-      'ClassDeclaration,ClassExpression': (node: ESTree.Node): void => {
-        if (
-          (node.type === 'ClassExpression' ||
-            node.type === 'ClassDeclaration') &&
-          isCustomElement(context, node, source.getJSDocComment(node))
-        ) {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (isCustomElement(context, node, source.getJSDocComment(node))) {
           insideElement = true;
         }
       },
       'ClassDeclaration,ClassExpression:exit': (): void => {
         insideElement = false;
       },
-      MethodDefinition: (node: ESTree.Node): void => {
+      MethodDefinition: (node: ESTree.MethodDefinition): void => {
         if (
           insideElement &&
-          node.type === 'MethodDefinition' &&
           node.kind === 'constructor' &&
           node.static === false &&
           node.key.type === 'Identifier' &&
@@ -150,21 +145,13 @@ const rule: Rule.RuleModule = {
       'MethodDefinition:exit': (): void => {
         insideConstructor = false;
       },
-      CallExpression: (node: ESTree.Node): void => {
-        if (
-          insideConstructor &&
-          node.type === 'CallExpression' &&
-          isBannedCallExpr(node)
-        ) {
+      CallExpression: (node: ESTree.CallExpression): void => {
+        if (insideConstructor && isBannedCallExpr(node)) {
           context.report({node: node, messageId: 'constructorAttrs'});
         }
       },
-      MemberExpression: (node: ESTree.Node): void => {
-        if (
-          insideConstructor &&
-          node.type === 'MemberExpression' &&
-          isBannedMember(node)
-        ) {
+      MemberExpression: (node: ESTree.MemberExpression): void => {
+        if (insideConstructor && isBannedMember(node)) {
           context.report({node: node, messageId: 'constructorAttrs'});
         }
       }

--- a/src/rules/no-constructor-params.ts
+++ b/src/rules/no-constructor-params.ts
@@ -51,12 +51,8 @@ const rule: Rule.RuleModule = {
     return {
       [`ClassExpression > ${constructorQuery}`]: visitConstructor,
       [`ClassDeclaration > ${constructorQuery}`]: visitConstructor,
-      'ClassDeclaration,ClassExpression': (node: ESTree.Node): void => {
-        if (
-          (node.type === 'ClassExpression' ||
-            node.type === 'ClassDeclaration') &&
-          isCustomElement(context, node, source.getJSDocComment(node))
-        ) {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (isCustomElement(context, node, source.getJSDocComment(node))) {
           insideElement = true;
         }
       },

--- a/src/rules/no-invalid-element-name.ts
+++ b/src/rules/no-invalid-element-name.ts
@@ -41,9 +41,8 @@ const rule: Rule.RuleModule = {
     //----------------------------------------------------------------------
 
     return {
-      CallExpression: (node: ESTree.Node): void => {
+      CallExpression: (node: ESTree.CallExpression): void => {
         if (
-          node.type === 'CallExpression' &&
           node.callee.type === 'MemberExpression' &&
           ((node.callee.object.type === 'MemberExpression' &&
             node.callee.object.object.type === 'Identifier' &&

--- a/src/rules/no-self-class.ts
+++ b/src/rules/no-self-class.ts
@@ -83,33 +83,21 @@ const rule: Rule.RuleModule = {
     //----------------------------------------------------------------------
 
     return {
-      'ClassDeclaration,ClassExpression': (node: ESTree.Node): void => {
-        if (
-          (node.type === 'ClassExpression' ||
-            node.type === 'ClassDeclaration') &&
-          isCustomElement(context, node, source.getJSDocComment(node))
-        ) {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (isCustomElement(context, node, source.getJSDocComment(node))) {
           insideElement = true;
         }
       },
       'ClassDeclaration,ClassExpression:exit': (): void => {
         insideElement = false;
       },
-      AssignmentExpression: (node: ESTree.Node): void => {
-        if (
-          insideElement &&
-          node.type === 'AssignmentExpression' &&
-          isBannedAssignmentExpr(node)
-        ) {
+      AssignmentExpression: (node: ESTree.AssignmentExpression): void => {
+        if (insideElement && isBannedAssignmentExpr(node)) {
           context.report({node: node, messageId: 'selfClass'});
         }
       },
-      CallExpression: (node: ESTree.Node): void => {
-        if (
-          insideElement &&
-          node.type === 'CallExpression' &&
-          isBannedCallExpr(node)
-        ) {
+      CallExpression: (node: ESTree.CallExpression): void => {
+        if (insideElement && isBannedCallExpr(node)) {
           context.report({node: node, messageId: 'selfClass'});
         }
       }

--- a/src/rules/no-typos.ts
+++ b/src/rules/no-typos.ts
@@ -47,20 +47,16 @@ const rule: Rule.RuleModule = {
     //----------------------------------------------------------------------
 
     return {
-      'ClassDeclaration,ClassExpression': (node: ESTree.Node): void => {
-        if (
-          (node.type === 'ClassExpression' ||
-            node.type === 'ClassDeclaration') &&
-          isCustomElement(context, node, source.getJSDocComment(node))
-        ) {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (isCustomElement(context, node, source.getJSDocComment(node))) {
           insideElement = true;
         }
       },
       'ClassDeclaration,ClassExpression:exit': (): void => {
         insideElement = false;
       },
-      MethodDefinition: (node: ESTree.Node): void => {
-        if (insideElement && node.type === 'MethodDefinition') {
+      MethodDefinition: (node: ESTree.MethodDefinition): void => {
+        if (insideElement) {
           if (
             node.kind === 'method' &&
             !node.static &&

--- a/src/test/util_test.ts
+++ b/src/test/util_test.ts
@@ -4,13 +4,15 @@ import {expect} from 'chai';
 import * as ESTree from 'estree';
 import {AST, Rule} from 'eslint';
 
-const parseExpr = (expr: string): ESTree.Node => {
+const parseExpr = (expr: string): ESTree.Class => {
   const parsed = parse(expr, {
     loc: true,
     ecmaVersion: 6,
     sourceType: 'module'
   });
-  return (parsed as ESTree.Program).body[0];
+  return (parsed as ESTree.Program).body[0] as
+    | ESTree.ClassDeclaration
+    | ESTree.ClassExpression;
 };
 
 const mockContext = ({

--- a/src/test/util_test.ts
+++ b/src/test/util_test.ts
@@ -23,6 +23,7 @@ describe('util', () => {
   describe('isCustomElement', () => {
     it('should parse direct sub classes of HTMLElement', () => {
       const doc = parseExpr(`class Foo extends HTMLElement {}`);
+      util.isCustomElement(mockContext, doc); // Primes the cache
       expect(util.isCustomElement(mockContext, doc)).to.equal(true);
     });
 

--- a/src/test/util_test.ts
+++ b/src/test/util_test.ts
@@ -4,15 +4,13 @@ import {expect} from 'chai';
 import * as ESTree from 'estree';
 import {AST, Rule} from 'eslint';
 
-const parseExpr = (expr: string): ESTree.Class => {
+const parseExpr = <T extends ESTree.Node = ESTree.Node>(expr: string): T => {
   const parsed = parse(expr, {
     loc: true,
     ecmaVersion: 6,
     sourceType: 'module'
   });
-  return (parsed as ESTree.Program).body[0] as
-    | ESTree.ClassDeclaration
-    | ESTree.ClassExpression;
+  return (parsed as ESTree.Program).body[0] as T;
 };
 
 const mockContext = ({
@@ -22,13 +20,13 @@ const mockContext = ({
 describe('util', () => {
   describe('isCustomElement', () => {
     it('should parse direct sub classes of HTMLElement', () => {
-      const doc = parseExpr(`class Foo extends HTMLElement {}`);
+      const doc = parseExpr<ESTree.Class>(`class Foo extends HTMLElement {}`);
       util.isCustomElement(mockContext, doc); // Primes the cache
       expect(util.isCustomElement(mockContext, doc)).to.equal(true);
     });
 
     it('should parse direct sub classes of custom bases', () => {
-      const doc = parseExpr(`class Foo extends MyBase {}`);
+      const doc = parseExpr<ESTree.Class>(`class Foo extends MyBase {}`);
       mockContext.settings = {
         wc: {
           elementBaseClasses: ['MyBase']
@@ -47,16 +45,16 @@ describe('util', () => {
           end: {line: 0, column: 0}
         }
       };
-      const doc = parseExpr(`/** @customElement **/
+      const doc = parseExpr<ESTree.Class>(`/** @customElement **/
         class Foo extends Bar {}`);
       expect(util.isCustomElement(mockContext, doc, jsdoc)).to.equal(true);
     });
 
     it('should be false for normal classes', () => {
-      let doc = parseExpr(`class Foo extends Bar {}`);
+      let doc = parseExpr<ESTree.Class>(`class Foo extends Bar {}`);
       expect(util.isCustomElement(mockContext, doc)).to.equal(false);
 
-      doc = parseExpr(`class Foo {}`);
+      doc = parseExpr<ESTree.Class>(`class Foo {}`);
       expect(util.isCustomElement(mockContext, doc)).to.equal(false);
     });
   });

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,7 +40,7 @@ export function isCustomElement(
   context: Rule.RuleContext,
   node: ESTree.Class,
   jsdoc?: AST.Token | null
-): node is ESTree.Class {
+): boolean {
   const asDecorated = node as WithDecorators<ESTree.Node>;
   const customElementBases: string[] = ['HTMLElement'];
   const cached = customElementsCache.get(node);
@@ -83,9 +83,7 @@ export function isCustomElement(
  * @param {ESTree.Class} node Node to test
  * @return {boolean}
  */
-export function isNativeCustomElement(
-  node: ESTree.Class
-): node is ESTree.Class {
+export function isNativeCustomElement(node: ESTree.Class): boolean {
   return (
     node.superClass?.type === 'Identifier' &&
     node.superClass.name === 'HTMLElement'

--- a/src/util.ts
+++ b/src/util.ts
@@ -33,7 +33,7 @@ export function isCustomElementDecorator(node: DecoratorNode): boolean {
  *
  * @param {Rule.RuleContext} context ESLint rule context
  * @param {ESTree.Class} node Node to test
- * @param {AST.Token} jsdoc JSDoc to parse
+ * @param {AST.Token=} jsdoc JSDoc to parse
  * @return {boolean}
  */
 export function isCustomElement(

--- a/src/util.ts
+++ b/src/util.ts
@@ -32,13 +32,13 @@ export function isCustomElementDecorator(node: DecoratorNode): boolean {
  * Determines if a node is an element class or not.
  *
  * @param {Rule.RuleContext} context ESLint rule context
- * @param {ESTree.Node} node Node to test
- * @param {AST.Token=} jsdoc JSDoc to parse
+ * @param {ESTree.Class} node Node to test
+ * @param {AST.Token} jsdoc JSDoc to parse
  * @return {boolean}
  */
 export function isCustomElement(
   context: Rule.RuleContext,
-  node: ESTree.Node,
+  node: ESTree.Class,
   jsdoc?: AST.Token | null
 ): node is ESTree.Class {
   const asDecorated = node as WithDecorators<ESTree.Node>;
@@ -49,41 +49,28 @@ export function isCustomElement(
     return cached;
   }
 
-  if (
-    context.settings.wc &&
-    Array.isArray(context.settings.wc.elementBaseClasses)
-  ) {
+  if (Array.isArray(context.settings.wc?.elementBaseClasses)) {
     customElementBases.push(
       ...(context.settings.wc.elementBaseClasses as string[])
     );
   }
 
-  if (node.type === 'ClassExpression' || node.type === 'ClassDeclaration') {
-    if (
-      node.superClass &&
-      node.superClass.type === 'Identifier' &&
-      customElementBases.includes(node.superClass.name)
-    ) {
-      customElementsCache.set(node, true);
-      return true;
-    }
+  if (
+    node.superClass?.type === 'Identifier' &&
+    customElementBases.includes(node.superClass.name)
+  ) {
+    customElementsCache.set(node, true);
+    return true;
+  }
 
-    if (
-      jsdoc !== undefined &&
-      jsdoc !== null &&
-      jsdoc.value.includes('@customElement')
-    ) {
-      customElementsCache.set(node, true);
-      return true;
-    }
+  if (jsdoc?.value.includes('@customElement')) {
+    customElementsCache.set(node, true);
+    return true;
+  }
 
-    if (
-      asDecorated.decorators !== undefined &&
-      asDecorated.decorators.some(isCustomElementDecorator)
-    ) {
-      customElementsCache.set(node, true);
-      return true;
-    }
+  if (asDecorated.decorators?.some(isCustomElementDecorator)) {
+    customElementsCache.set(node, true);
+    return true;
   }
 
   customElementsCache.set(node, false);
@@ -93,15 +80,14 @@ export function isCustomElement(
 /**
  * Determines if a node is an extension of HTMLElement class or not.
  *
- * @param {ESTree.Node} node Node to test
+ * @param {ESTree.Class} node Node to test
  * @return {boolean}
  */
-export function isNativeCustomElement(node: ESTree.Node): node is ESTree.Class {
+export function isNativeCustomElement(
+  node: ESTree.Class
+): node is ESTree.Class {
   return (
-    (node.type === 'ClassExpression' || node.type === 'ClassDeclaration') &&
-    node.superClass !== undefined &&
-    node.superClass !== null &&
-    node.superClass.type === 'Identifier' &&
+    node.superClass?.type === 'Identifier' &&
     node.superClass.name === 'HTMLElement'
   );
 }


### PR DESCRIPTION
The returned functions on the tree traverser return the type that the key specifies. By setting the param as `ESTree.Node` we were making it more generic and then required a check that it would be the type that it passes in. 

I simplified the typing to what it should be and removed the redundant checks.

Also, utilized the optional chaining operator in the util file to simplify the conditions a bit