### PR TITLE
Add missing rules to index exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "eslint-plugin-wc",
       "version": "1.3.1",
       "license": "MIT",
       "dependencies": {

--- a/src/configs/best-practice.ts
+++ b/src/configs/best-practice.ts
@@ -6,7 +6,9 @@ const config = {
     'wc/attach-shadow-constructor': 'error',
     'wc/guard-super-call': 'error',
     'wc/no-closed-shadow-root': 'error',
-    'wc/no-typos': 'error'
+    'wc/no-constructor-params': 'error',
+    'wc/no-typos': 'error',
+    'wc/require-listener-teardown': 'error'
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,18 +4,22 @@ import attachShadowConstructor from './rules/attach-shadow-constructor';
 import guardSuperCall from './rules/guard-super-call';
 import noClosedShadowRoot from './rules/no-closed-shadow-root';
 import noConstructorAttrs from './rules/no-constructor-attributes';
+import noConstructorParams from './rules/no-constructor-params';
 import noInvalidElementName from './rules/no-invalid-element-name';
 import noSelfClass from './rules/no-self-class';
 import noTypos from './rules/no-typos';
+import requireListenerTeardown from './rules/require-listener-teardown';
 
 export const rules = {
   'attach-shadow-constructor': attachShadowConstructor,
   'guard-super-call': guardSuperCall,
   'no-closed-shadow-root': noClosedShadowRoot,
   'no-constructor-attributes': noConstructorAttrs,
+  'no-constructor-params': noConstructorParams,
   'no-invalid-element-name': noInvalidElementName,
   'no-self-class': noSelfClass,
-  'no-typos': noTypos
+  'no-typos': noTypos,
+  'require-listener-teardown': requireListenerTeardown
 };
 
 export const configs = {

--- a/src/rules/require-listener-teardown.ts
+++ b/src/rules/require-listener-teardown.ts
@@ -85,4 +85,4 @@ const rule: Rule.RuleModule = {
   }
 };
 
-export = rule;
+export default rule;

--- a/src/test/rules/require-listener-teardown_test.ts
+++ b/src/test/rules/require-listener-teardown_test.ts
@@ -7,7 +7,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-import rule = require('../../rules/require-listener-teardown');
+import rule from '../../rules/require-listener-teardown';
 import {RuleTester} from 'eslint';
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Some rules were missing from the index, which prevents those rules from being referenced by existing configs or being set by devs. This adds all existing rules to the index and adds the missing ones to the `best-practices` preset for completion.

--

This resolves https://github.com/43081j/eslint-plugin-wc/issues/68 and https://github.com/43081j/eslint-plugin-wc/issues/69