### PR TITLE
feat (require-listener-teardown): detect inline functions and documen…

### DIFF
--- a/src/test/rules/require-listener-teardown_test.ts
+++ b/src/test/rules/require-listener-teardown_test.ts
@@ -66,6 +66,18 @@ ruleTester.run('require-listener-teardown', rule, {
         this.something.addEventListener('x', console.log);
       }
     }`
+    },
+    {
+      code: `class Foo extends HTMLElement {
+      connectedCallback() {
+        this.addEventListener('foo', console.log);
+      }
+    }`,
+      options: [
+        {
+          hosts: ['window', 'document']
+        }
+      ]
     }
   ],
 
@@ -157,6 +169,69 @@ ruleTester.run('require-listener-teardown', rule, {
           messageId: 'noTeardown',
           line: 3,
           column: 11
+        }
+      ]
+    },
+    {
+      code: `class Foo extends HMTLElement {
+        connectedCallback() {
+          foo.addEventListener('x', console.log);
+        }
+      }`,
+      options: [
+        {
+          hosts: ['foo']
+        }
+      ],
+      errors: [
+        {
+          messageId: 'noTeardown',
+          line: 3,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class Foo extends HMTLElement {
+        connectedCallback() {
+          this.addEventListener('x', this.foo.bind(this));
+        }
+        disconnectedCallback() {
+          this.removeEventListener('x', this.foo.bind(this));
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'noArrowBind',
+          line: 3,
+          column: 38
+        },
+        {
+          messageId: 'noArrowBind',
+          line: 6,
+          column: 41
+        }
+      ]
+    },
+    {
+      code: `class Foo extends HMTLElement {
+        connectedCallback() {
+          this.addEventListener('x', () => {});
+        }
+        disconnectedCallback() {
+          this.removeEventListener('x', () => {});
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'noArrowBind',
+          line: 3,
+          column: 38
+        },
+        {
+          messageId: 'noArrowBind',
+          line: 6,
+          column: 41
         }
       ]
     }


### PR DESCRIPTION
Fixes #79 

Introduces these changes:

- The rule has options now so you can specify `{hosts: ['window', 'document']}` for example to no longer check for handlers on `this`
- It now also detects inline functions (arrow functions, bind), e.g. `addEventListener('foo', this.foo.bind(this))`
- detects events on `this`, `window` and `document` by default (used to be just `this`)