### PR TITLE
feat (expose-class-on-global): new rule

### DIFF
--- a/src/rules/expose-class-on-global.ts
+++ b/src/rules/expose-class-on-global.ts
@@ -1,0 +1,97 @@
+/**
+ * @fileoverview Enforces that custom element classes are exposed on the
+ * global object (i.e. `window`)
+ * @author James Garbutt <https://github.com/43081j>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {isCustomElement} from '../util';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description:
+        'Enforces that custom element classes are exposed on the ' +
+        'global object (i.e. window)',
+      url: 'https://github.com/43081j/eslint-plugin-wc/blob/master/docs/rules/expose-class-on-global.md'
+    },
+    messages: {
+      expose:
+        'Custom element classes should be exposed on the global ' +
+        'object (i.e. window)',
+      sameName:
+        'The exposed global name should match that of the ' +
+        'custom element class'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    const seenClasses = new Set<ESTree.Node>();
+    const source = context.getSourceCode();
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+    const globalNames = new Set<string>(['window', 'globalThis']);
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (
+          isCustomElement(context, node, source.getJSDocComment(node)) &&
+          node.id?.type === 'Identifier'
+        ) {
+          seenClasses.add(node);
+        }
+      },
+      'AssignmentExpression:exit': (
+        node: ESTree.AssignmentExpression
+      ): void => {
+        if (
+          node.left.type === 'MemberExpression' &&
+          node.left.object.type === 'Identifier' &&
+          globalNames.has(node.left.object.name) &&
+          node.left.property.type === 'Identifier' &&
+          node.right.type === 'Identifier'
+        ) {
+          const className = node.right.name;
+          const ref = context
+            .getScope()
+            .references.find((r) => r.identifier.name === className);
+          if (ref?.resolved && ref.resolved.defs.length === 1) {
+            const classDef = ref.resolved.defs[0].node;
+
+            seenClasses.delete(classDef);
+
+            if (classDef.id.name !== node.left.property.name) {
+              context.report({
+                node,
+                messageId: 'sameName'
+              });
+            }
+          }
+        }
+      },
+      'Program:exit': (): void => {
+        for (const node of seenClasses) {
+          context.report({
+            node,
+            messageId: 'expose'
+          });
+        }
+
+        seenClasses.clear();
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/test/rules/expose-class-on-global_test.ts
+++ b/src/test/rules/expose-class-on-global_test.ts
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview Enforces that custom element classes are exposed on the
+ * global object (i.e. `window`)
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule from '../../rules/expose-class-on-global';
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+ruleTester.run('expose-class-on-global', rule, {
+  valid: [
+    'class Foo {}',
+    `class Foo extends HTMLElement {}
+    window.Foo = Foo`,
+    `class Foo extends HTMLElement {}
+    globalThis.Foo = Foo`,
+    `class Foo extends HTMLElement {}
+    const x = 303;
+    window.Foo = Foo;`,
+    `/** @customElement x-foo */
+    class Foo extends Bar {}
+    window.Foo = Foo;`,
+    'class Foo extends Bar{}',
+    `window.Foo = Bar;`,
+    {
+      code: `class Foo extends Bar {}
+      window.Foo = Foo;`,
+      settings: {
+        wc: {
+          elementBaseClasses: ['Bar']
+        }
+      }
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class Foo extends HTMLElement {}`,
+      errors: [
+        {
+          messageId: 'expose',
+          line: 1,
+          column: 1
+        }
+      ]
+    },
+    {
+      code: `window.Foo = Foo;
+      class Foo extends HTMLElement {}`,
+      errors: [
+        {
+          messageId: 'expose',
+          line: 2,
+          column: 7
+        }
+      ]
+    },
+    {
+      code: `/** @customElement x-foo */
+      class Foo extends Bar {}`,
+      errors: [
+        {
+          messageId: 'expose',
+          line: 2,
+          column: 7
+        }
+      ]
+    },
+    {
+      code: 'class Foo extends Bar {}',
+      settings: {
+        wc: {
+          elementBaseClasses: ['Bar']
+        }
+      },
+      errors: [
+        {
+          messageId: 'expose',
+          line: 1,
+          column: 1
+        }
+      ]
+    },
+    {
+      code: `class Foo extends HTMLElement {}
+      window.x = Foo;`,
+      errors: [
+        {
+          messageId: 'sameName',
+          line: 2,
+          column: 7
+        }
+      ]
+    },
+    {
+      code: `class Foo extends HTMLElement {}
+      globalThis.x = Foo;`,
+      errors: [
+        {
+          messageId: 'sameName',
+          line: 2,
+          column: 7
+        }
+      ]
+    },
+    {
+      code: `class Foo extends HTMLElement {}
+      window.deep.path = Foo;`,
+      errors: [
+        {
+          messageId: 'expose',
+          line: 1,
+          column: 1
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
Part of #82 

This one enforces that you define your custom elements on the global object