### PR TITLE
feat (no-constructor): new rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,21 @@
-import recommended from './configs/recommended';
-import bestPractice from './configs/best-practice';
 import attachShadowConstructor from './rules/attach-shadow-constructor';
+import bestPractice from './configs/best-practice';
 import guardSuperCall from './rules/guard-super-call';
 import noClosedShadowRoot from './rules/no-closed-shadow-root';
+import noConstructor from './rules/no-constructor';
 import noConstructorAttrs from './rules/no-constructor-attributes';
 import noConstructorParams from './rules/no-constructor-params';
 import noInvalidElementName from './rules/no-invalid-element-name';
 import noSelfClass from './rules/no-self-class';
 import noTypos from './rules/no-typos';
+import recommended from './configs/recommended';
 import requireListenerTeardown from './rules/require-listener-teardown';
 
 export const rules = {
   'attach-shadow-constructor': attachShadowConstructor,
   'guard-super-call': guardSuperCall,
   'no-closed-shadow-root': noClosedShadowRoot,
+  'no-constructor': noConstructor,
   'no-constructor-attributes': noConstructorAttrs,
   'no-constructor-params': noConstructorParams,
   'no-invalid-element-name': noInvalidElementName,

--- a/src/rules/no-constructor.ts
+++ b/src/rules/no-constructor.ts
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview Disallows constructors in custom element classes
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {isCustomElement} from '../util';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Disallows constructors in custom element classes',
+      url: 'https://github.com/43081j/eslint-plugin-wc/blob/master/docs/rules/no-constructor.md'
+    },
+    messages: {
+      noConstructor:
+        'Constructors should be avoided in custom elements. ' +
+        'Consider using lifecycle methods instead (e.g. `connectedCallback`)'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+    let insideElement = false;
+    const source = context.getSourceCode();
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (isCustomElement(context, node, source.getJSDocComment(node))) {
+          insideElement = true;
+        }
+      },
+      'ClassDeclaration,ClassExpression:exit': (): void => {
+        insideElement = false;
+      },
+      MethodDefinition: (node: ESTree.MethodDefinition): void => {
+        if (
+          insideElement &&
+          node.kind === 'constructor' &&
+          node.key.type === 'Identifier' &&
+          node.key.name === 'constructor'
+        ) {
+          context.report({
+            node,
+            messageId: 'noConstructor'
+          });
+        }
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/test/rules/no-constructor_test.ts
+++ b/src/test/rules/no-constructor_test.ts
@@ -1,0 +1,112 @@
+/**
+ * @fileoverview Disallows constructors in custom element classes
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule from '../../rules/no-constructor';
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+const parser = require.resolve('@typescript-eslint/parser');
+
+ruleTester.run('no-constructor', rule, {
+  valid: [
+    {
+      code: `class A {
+      constructor() {
+      }
+    }`
+    },
+    {
+      code: `class A extends B {
+      constructor() {
+        super();
+      }
+    }`
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class A extends HTMLElement {
+        constructor() {
+          super();
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'noConstructor',
+          line: 2,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `class A extends Element {
+        constructor() {
+          super();
+        }
+      }`,
+      settings: {
+        wc: {
+          elementBaseClasses: ['Element']
+        }
+      },
+      errors: [
+        {
+          messageId: 'noConstructor',
+          line: 2,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `/**
+       * @customElement
+       */
+      class A extends Element {
+        constructor() {
+          super();
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'noConstructor',
+          line: 5,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `@customElement('x-foo')
+      class A extends Element {
+        constructor() {
+          super();
+        }
+      }`,
+      parser,
+      errors: [
+        {
+          messageId: 'noConstructor',
+          line: 3,
+          column: 9
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
This rule allows you to disallow constructors in custom element classes.

It is really a personal preference rule rather than best practice.

Some users may wish to disallow it to avoid problems around reconnection to DOM, etc.