### PR TITLE
feat (no-child-traversal-in-attributechangedcallback): new rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import attachShadowConstructor from './rules/attach-shadow-constructor';
 import bestPractice from './configs/best-practice';
 import guardSuperCall from './rules/guard-super-call';
 import maxElementsPerFile from './rules/max-elements-per-file';
+import noChildInAttrChange from './rules/no-child-traversal-in-attributechangedcallback';
 import noClosedShadowRoot from './rules/no-closed-shadow-root';
 import noConstructor from './rules/no-constructor';
 import noConstructorAttrs from './rules/no-constructor-attributes';
@@ -18,6 +19,7 @@ export const rules = {
   'attach-shadow-constructor': attachShadowConstructor,
   'guard-super-call': guardSuperCall,
   'max-elements-per-file': maxElementsPerFile,
+  'no-child-traversal-in-attributechangedcallback': noChildInAttrChange,
   'no-closed-shadow-root': noClosedShadowRoot,
   'no-constructor': noConstructor,
   'no-constructor-attributes': noConstructorAttrs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import bestPractice from './configs/best-practice';
 import guardSuperCall from './rules/guard-super-call';
 import maxElementsPerFile from './rules/max-elements-per-file';
 import noChildInAttrChange from './rules/no-child-traversal-in-attributechangedcallback';
+import noChildInConnected from './rules/no-child-traversal-in-connectedcallback';
 import noClosedShadowRoot from './rules/no-closed-shadow-root';
 import noConstructor from './rules/no-constructor';
 import noConstructorAttrs from './rules/no-constructor-attributes';
@@ -20,6 +21,7 @@ export const rules = {
   'guard-super-call': guardSuperCall,
   'max-elements-per-file': maxElementsPerFile,
   'no-child-traversal-in-attributechangedcallback': noChildInAttrChange,
+  'no-child-traversal-in-connectedcallback': noChildInConnected,
   'no-closed-shadow-root': noClosedShadowRoot,
   'no-constructor': noConstructor,
   'no-constructor-attributes': noConstructorAttrs,

--- a/src/rules/no-child-traversal-in-attributechangedcallback.ts
+++ b/src/rules/no-child-traversal-in-attributechangedcallback.ts
@@ -1,0 +1,166 @@
+/**
+ * @fileoverview Disallows traversal of children in the
+ * `AttributeChangedCallback` method
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {isCustomElement} from '../util';
+
+const disallowedProperties = new Set<string>([
+  // ParentNode
+  'childElementCount',
+  'children',
+  'firstElementChild',
+  'lastElementChild',
+
+  // Node
+  'childNodes',
+  'firstChild',
+  'innerHTML',
+  'innerText',
+  'lastChild',
+  'textContent'
+]);
+const disallowedMethods = new Set<string>([
+  // Document
+  'getElementById',
+  'getElementsByClassName',
+  'getElementsByTagName',
+
+  // ParentNode
+  'querySelector',
+  'querySelectorAll',
+
+  // Node
+  'contains',
+  'hasChildNodes',
+  'insertBefore',
+  'removeChild',
+  'replaceChild'
+]);
+
+/**
+ * Determines if a node is `this.*` or `this.shadowRoot.*`
+ * @param {ESTree.Node} node Node to test
+ * @return {boolean}
+ */
+function isThisOrShadowRoot(node: ESTree.Node): boolean {
+  return (
+    node.type === 'ThisExpression' ||
+    (node.type === 'MemberExpression' &&
+      node.object.type === 'ThisExpression' &&
+      node.property.type === 'Identifier' &&
+      node.property.name === 'shadowRoot')
+  );
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description:
+        'Disallows traversal of children in the ' +
+        '`AttributeChangedCallback` method',
+      url: 'https://github.com/43081j/eslint-plugin-wc/blob/master/docs/rules/no-child-traversal-in-attributechangedcallback.md'
+    },
+    messages: {
+      domMethod:
+        'Traversing children in the `attributeChangedCallback` ' +
+        'method is error prone and should be avoided',
+      domProp:
+        'Accessing local DOM properties in the ' +
+        '`attributeChangedCallback` method is error prone and should be avoided'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+    let insideCallback = false;
+    let insideElement = false;
+    const source = context.getSourceCode();
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (isCustomElement(context, node, source.getJSDocComment(node))) {
+          insideElement = true;
+        }
+      },
+      'ClassDeclaration,ClassExpression:exit': (): void => {
+        insideElement = false;
+      },
+      MethodDefinition: (node: ESTree.MethodDefinition): void => {
+        if (
+          insideElement &&
+          !node.static &&
+          node.key.type === 'Identifier' &&
+          node.key.name === 'attributeChangedCallback'
+        ) {
+          insideCallback = true;
+        }
+      },
+      'MethodDefinition:exit': (): void => {
+        insideCallback = false;
+      },
+      MemberExpression: (
+        node: ESTree.MemberExpression & Rule.NodeParentExtension
+      ): void => {
+        if (!insideCallback) {
+          return;
+        }
+
+        if (node.property.type !== 'Identifier') {
+          // Don't bother with expressions that have funky properties
+          return;
+        }
+
+        const parentNode = node.parent;
+
+        if (parentNode.type === 'AssignmentExpression') {
+          // Allow things like textContent/innerHTML assignments
+          return;
+        }
+
+        const name = node.property.name;
+
+        if (!isThisOrShadowRoot(node.object)) {
+          // Only look for `this.*` or `this.shadowRoot.*`
+          return;
+        }
+
+        if (disallowedProperties.has(name)) {
+          context.report({
+            node,
+            messageId: 'domProp'
+          });
+        }
+
+        if (
+          parentNode.type === 'CallExpression' &&
+          parentNode.callee === node &&
+          disallowedMethods.has(name)
+        ) {
+          context.report({
+            node,
+            messageId: 'domMethod'
+          });
+        }
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/test/rules/no-child-traversal-in-attributechangedcallback_test.ts
+++ b/src/test/rules/no-child-traversal-in-attributechangedcallback_test.ts
@@ -1,0 +1,157 @@
+/**
+ * @fileoverview Disallows traversal of children in the
+ * `AttributeChangedCallback` method
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule from '../../rules/no-child-traversal-in-attributechangedcallback';
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+const parser = require.resolve('@typescript-eslint/parser');
+
+ruleTester.run('no-child-traversal-in-attributechangedcallback', rule, {
+  valid: [
+    'const x = 808;',
+    {
+      code: `class A extends HTMLElement {
+        someMethod() {
+          this.querySelector('xyz');
+        }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      attributeChangedCallback() {
+        foo;
+      }
+    }`
+    },
+    {
+      code: `/**
+     * @customElement
+     */
+    class A extends SomeElement {
+      attributeChangedCallback() {
+        foo;
+      }
+    }`
+    },
+    {
+      code: `class A extends SomeElement {
+        attributeChangedCallback() {
+          foo;
+        }
+      }`,
+      settings: {
+        wc: {
+          elementBaseClasses: ['SomeElement']
+        }
+      }
+    },
+    {
+      code: `@customElement('x-foo')
+      class A extends SomeElement {
+        attributeChangedCallback() {
+          foo;
+        }
+      }`,
+      parser
+    },
+    {
+      code: `class A extends HTMLElement {
+      attributeChangedCallback() {
+        this.textContent = 'foo';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      attributeChangedCallback() {
+        this.shadowRoot.textContent = 'foo';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      attributeChangedCallback() {
+        this.innerHTML = '<div></div>';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      attributeChangedCallback() {
+        this.shadowRoot.innerHTML = '<div></div>';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      attributeChangedCallback() {
+        this.someOtherThing.querySelector('xyz');
+      }
+    }`
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class A extends HTMLElement {
+        attributeChangedCallback() {
+          this.shadowRoot.querySelector('foo');
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 3,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        attributeChangedCallback() {
+          this.querySelector('foo');
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 3,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        attributeChangedCallback() {
+          const foo = this.children[0];
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domProp',
+          line: 3,
+          column: 23
+        }
+      ]
+    }
+  ]
+});

--- a/src/test/rules/no-child-traversal-in-attributechangedcallback_test.ts
+++ b/src/test/rules/no-child-traversal-in-attributechangedcallback_test.ts
@@ -28,6 +28,7 @@ const parser = require.resolve('@typescript-eslint/parser');
 ruleTester.run('no-child-traversal-in-attributechangedcallback', rule, {
   valid: [
     'const x = 808;',
+    'class UnrelatedClass {}',
     {
       code: `class A extends HTMLElement {
         someMethod() {
@@ -150,6 +151,44 @@ ruleTester.run('no-child-traversal-in-attributechangedcallback', rule, {
           messageId: 'domProp',
           line: 3,
           column: 23
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        attributeChangedCallback() {
+          this.addEventListener('foo', () => {
+            const node = this.querySelector('foo');
+            if (node) {
+              node.click();
+            }
+          });
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 4,
+          column: 26
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        attributeChangedCallback() {
+          new MutationObserver(() => {
+            const node = this.querySelector('foo');
+            if (node) {
+              node.click();
+            }
+          });
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 4,
+          column: 26
         }
       ]
     }

--- a/src/test/rules/no-child-traversal-in-connectedcallback_test.ts
+++ b/src/test/rules/no-child-traversal-in-connectedcallback_test.ts
@@ -1,0 +1,207 @@
+/**
+ * @fileoverview Disallows traversal of children in the
+ * `connectedCallback` method
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule from '../../rules/no-child-traversal-in-connectedcallback';
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+const parser = require.resolve('@typescript-eslint/parser');
+
+ruleTester.run('no-child-traversal-in-connectedcallback', rule, {
+  valid: [
+    'const x = 808;',
+    {
+      code: `class A extends HTMLElement {
+        someMethod() {
+          this.querySelector('xyz');
+        }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        foo;
+      }
+    }`
+    },
+    {
+      code: `/**
+     * @customElement
+     */
+    class A extends SomeElement {
+      connectedCallback() {
+        foo;
+      }
+    }`
+    },
+    {
+      code: `class A extends SomeElement {
+        connectedCallback() {
+          foo;
+        }
+      }`,
+      settings: {
+        wc: {
+          elementBaseClasses: ['SomeElement']
+        }
+      }
+    },
+    {
+      code: `@customElement('x-foo')
+      class A extends SomeElement {
+        connectedCallback() {
+          foo;
+        }
+      }`,
+      parser
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.textContent = 'foo';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.shadowRoot.textContent = 'foo';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.innerHTML = '<div></div>';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.shadowRoot.innerHTML = '<div></div>';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.someOtherThing.querySelector('xyz');
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.addEventListener('foo', () => {
+          this.querySelector('woo');
+        });
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.observer = new MutationObserver((muts) => {
+          this.querySelector('woo');
+        });
+      }
+    }`
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class A extends HTMLElement {
+        connectedCallback() {
+          this.shadowRoot.querySelector('foo');
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 3,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        connectedCallback() {
+          this.querySelector('foo');
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 3,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        connectedCallback() {
+          const foo = this.children[0];
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domProp',
+          line: 3,
+          column: 23
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        connectedCallback() {
+          for (const x of y) {
+            this.querySelector('abc');
+          }
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 4,
+          column: 13
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        connectedCallback() {
+          foo['bar'](() => {
+            this.querySelector('abc');
+          });
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 4,
+          column: 13
+        }
+      ]
+    }
+  ]
+});

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -1,0 +1,50 @@
+import * as ESTree from 'estree';
+
+export const childPropertyList = new Set<string>([
+  // ParentNode
+  'childElementCount',
+  'children',
+  'firstElementChild',
+  'lastElementChild',
+
+  // Node
+  'childNodes',
+  'firstChild',
+  'innerHTML',
+  'innerText',
+  'lastChild',
+  'textContent'
+]);
+
+export const childMethodList = new Set<string>([
+  // Document
+  'getElementById',
+  'getElementsByClassName',
+  'getElementsByTagName',
+
+  // ParentNode
+  'querySelector',
+  'querySelectorAll',
+
+  // Node
+  'contains',
+  'hasChildNodes',
+  'insertBefore',
+  'removeChild',
+  'replaceChild'
+]);
+
+/**
+ * Determines if a node is `this.*` or `this.shadowRoot.*`
+ * @param {ESTree.Node} node Node to test
+ * @return {boolean}
+ */
+export function isThisOrShadowRoot(node: ESTree.Node): boolean {
+  return (
+    node.type === 'ThisExpression' ||
+    (node.type === 'MemberExpression' &&
+      node.object.type === 'ThisExpression' &&
+      node.property.type === 'Identifier' &&
+      node.property.name === 'shadowRoot')
+  );
+}


### PR DESCRIPTION
basically disallows querySelector, childNodes, etc etc in `attributeChangedCallback` - but specifically on `this` and `this.shadowRoot`