### PR TITLE
feat (no-child-traversal-in-connectedcallback): new rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import bestPractice from './configs/best-practice';
 import guardSuperCall from './rules/guard-super-call';
 import maxElementsPerFile from './rules/max-elements-per-file';
 import noChildInAttrChange from './rules/no-child-traversal-in-attributechangedcallback';
+import noChildInConnected from './rules/no-child-traversal-in-connectedcallback';
 import noClosedShadowRoot from './rules/no-closed-shadow-root';
 import noConstructor from './rules/no-constructor';
 import noConstructorAttrs from './rules/no-constructor-attributes';
@@ -20,6 +21,7 @@ export const rules = {
   'guard-super-call': guardSuperCall,
   'max-elements-per-file': maxElementsPerFile,
   'no-child-traversal-in-attributechangedcallback': noChildInAttrChange,
+  'no-child-traversal-in-connectedcallback': noChildInConnected,
   'no-closed-shadow-root': noClosedShadowRoot,
   'no-constructor': noConstructor,
   'no-constructor-attributes': noConstructorAttrs,

--- a/src/test/rules/no-child-traversal-in-connectedcallback_test.ts
+++ b/src/test/rules/no-child-traversal-in-connectedcallback_test.ts
@@ -1,0 +1,207 @@
+/**
+ * @fileoverview Disallows traversal of children in the
+ * `connectedCallback` method
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule from '../../rules/no-child-traversal-in-connectedcallback';
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+const parser = require.resolve('@typescript-eslint/parser');
+
+ruleTester.run('no-child-traversal-in-connectedcallback', rule, {
+  valid: [
+    'const x = 808;',
+    {
+      code: `class A extends HTMLElement {
+        someMethod() {
+          this.querySelector('xyz');
+        }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        foo;
+      }
+    }`
+    },
+    {
+      code: `/**
+     * @customElement
+     */
+    class A extends SomeElement {
+      connectedCallback() {
+        foo;
+      }
+    }`
+    },
+    {
+      code: `class A extends SomeElement {
+        connectedCallback() {
+          foo;
+        }
+      }`,
+      settings: {
+        wc: {
+          elementBaseClasses: ['SomeElement']
+        }
+      }
+    },
+    {
+      code: `@customElement('x-foo')
+      class A extends SomeElement {
+        connectedCallback() {
+          foo;
+        }
+      }`,
+      parser
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.textContent = 'foo';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.shadowRoot.textContent = 'foo';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.innerHTML = '<div></div>';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.shadowRoot.innerHTML = '<div></div>';
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.someOtherThing.querySelector('xyz');
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.addEventListener('foo', () => {
+          this.querySelector('woo');
+        });
+      }
+    }`
+    },
+    {
+      code: `class A extends HTMLElement {
+      connectedCallback() {
+        this.observer = new MutationObserver((muts) => {
+          this.querySelector('woo');
+        });
+      }
+    }`
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class A extends HTMLElement {
+        connectedCallback() {
+          this.shadowRoot.querySelector('foo');
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 3,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        connectedCallback() {
+          this.querySelector('foo');
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 3,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        connectedCallback() {
+          const foo = this.children[0];
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domProp',
+          line: 3,
+          column: 23
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        connectedCallback() {
+          for (const x of y) {
+            this.querySelector('abc');
+          }
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 4,
+          column: 13
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        connectedCallback() {
+          foo['bar'](() => {
+            this.querySelector('abc');
+          });
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'domMethod',
+          line: 4,
+          column: 13
+        }
+      ]
+    }
+  ]
+});

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -1,0 +1,50 @@
+import * as ESTree from 'estree';
+
+export const childPropertyList = new Set<string>([
+  // ParentNode
+  'childElementCount',
+  'children',
+  'firstElementChild',
+  'lastElementChild',
+
+  // Node
+  'childNodes',
+  'firstChild',
+  'innerHTML',
+  'innerText',
+  'lastChild',
+  'textContent'
+]);
+
+export const childMethodList = new Set<string>([
+  // Document
+  'getElementById',
+  'getElementsByClassName',
+  'getElementsByTagName',
+
+  // ParentNode
+  'querySelector',
+  'querySelectorAll',
+
+  // Node
+  'contains',
+  'hasChildNodes',
+  'insertBefore',
+  'removeChild',
+  'replaceChild'
+]);
+
+/**
+ * Determines if a node is `this.*` or `this.shadowRoot.*`
+ * @param {ESTree.Node} node Node to test
+ * @return {boolean}
+ */
+export function isThisOrShadowRoot(node: ESTree.Node): boolean {
+  return (
+    node.type === 'ThisExpression' ||
+    (node.type === 'MemberExpression' &&
+      node.object.type === 'ThisExpression' &&
+      node.property.type === 'Identifier' &&
+      node.property.name === 'shadowRoot')
+  );
+}


### PR DESCRIPTION
same as the one for attribute changed callback, but for `connectedCallback`

basically disallows child traversals in there