### PR TITLE
feat (max-elements-per-file): new rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,20 @@
-import recommended from './configs/recommended';
-import bestPractice from './configs/best-practice';
 import attachShadowConstructor from './rules/attach-shadow-constructor';
+import bestPractice from './configs/best-practice';
 import guardSuperCall from './rules/guard-super-call';
+import maxElementsPerFile from './rules/max-elements-per-file';
 import noClosedShadowRoot from './rules/no-closed-shadow-root';
 import noConstructorAttrs from './rules/no-constructor-attributes';
 import noConstructorParams from './rules/no-constructor-params';
 import noInvalidElementName from './rules/no-invalid-element-name';
 import noSelfClass from './rules/no-self-class';
 import noTypos from './rules/no-typos';
+import recommended from './configs/recommended';
 import requireListenerTeardown from './rules/require-listener-teardown';
 
 export const rules = {
   'attach-shadow-constructor': attachShadowConstructor,
   'guard-super-call': guardSuperCall,
+  'max-elements-per-file': maxElementsPerFile,
   'no-closed-shadow-root': noClosedShadowRoot,
   'no-constructor-attributes': noConstructorAttrs,
   'no-constructor-params': noConstructorParams,

--- a/src/rules/max-elements-per-file.ts
+++ b/src/rules/max-elements-per-file.ts
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Enforces a maximum number of elements per file
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {isCustomElement} from '../util';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Enforces a maximum number of elements per file',
+      url: 'https://github.com/43081j/eslint-plugin-wc/blob/master/docs/rules/max-elements-per-file.md'
+    },
+    messages: {
+      tooMany: 'Only {{count}} element(s) should be defined per individual file'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          max: {
+            type: 'integer',
+            minimum: 1
+          }
+        }
+      }
+    ]
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+    const source = context.getSourceCode();
+    const maxElements = context.options[0]?.max ?? 1;
+    let elementCount = 0;
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (
+          isCustomElement(context, node, source.getJSDocComment(node)) &&
+          ++elementCount > maxElements
+        ) {
+          context.report({
+            node,
+            messageId: 'tooMany',
+            data: {count: maxElements}
+          });
+        }
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/test/rules/max-elements-per-file_test.ts
+++ b/src/test/rules/max-elements-per-file_test.ts
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview Enforces a maximum number of elements per file
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule from '../../rules/max-elements-per-file';
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+const parser = require.resolve('@typescript-eslint/parser');
+
+ruleTester.run('max-elements-per-file', rule, {
+  valid: [
+    'const x = 505;',
+    {
+      code: 'class A extends HTMLElement {}'
+    },
+    {
+      code: `
+        class A extends HTMLElement {}
+        class B extends HTMLElement {}
+      `,
+      options: [
+        {
+          max: 2
+        }
+      ]
+    },
+    {
+      code: `/**
+     * @customElement
+     */
+    class A extends Element {}`
+    },
+    {
+      code: 'class A extends SomeElement {}',
+      settings: {
+        wc: {
+          elementBaseClasses: ['SomeElement']
+        }
+      }
+    },
+    {
+      code: `@customElement('x-foo')
+      class A extends SomeElement {}`,
+      parser
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+        class A extends HTMLElement {}
+        class B extends HTMLElement {}
+      `,
+      errors: [
+        {
+          messageId: 'tooMany',
+          data: {count: 1},
+          line: 3,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `
+        class A extends HTMLElement {}
+        class B extends HTMLElement {}
+        class C extends HTMLElement {}
+      `,
+      options: [
+        {
+          max: 2
+        }
+      ],
+      errors: [
+        {
+          messageId: 'tooMany',
+          data: {count: 2},
+          line: 4,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `
+        class A extends SomeElement {}
+        class B extends SomeElement {}
+      `,
+      settings: {
+        wc: {
+          elementBaseClasses: ['SomeElement']
+        }
+      },
+      errors: [
+        {
+          messageId: 'tooMany',
+          data: {count: 1},
+          line: 3,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `
+        /**
+         * @customElement
+         */
+        class A extends SomeElement {}
+        class B extends HTMLElement {}
+      `,
+      errors: [
+        {
+          messageId: 'tooMany',
+          line: 6,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `
+        @customElement('x-a')
+        class A extends SomeElement {}
+        class B extends HTMLElement {}
+      `,
+      parser,
+      errors: [
+        {
+          messageId: 'tooMany',
+          line: 4,
+          column: 9
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
Behaves the same way as `max-classes-per-file` but for elements, defaults to `1` per file