### PR TITLE
feat (tag-name-matches-class): new rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   "rules": {
     "indent": "off",
     "quote-props": "off",
+    "operator-linebreak": "off",
     "max-len": [
       "error",
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import noInvalidElementName from './rules/no-invalid-element-name';
 import noSelfClass from './rules/no-self-class';
 import noTypos from './rules/no-typos';
 import requireListenerTeardown from './rules/require-listener-teardown';
+import tagMatchesClass from './rules/tag-name-matches-class';
 
 export const rules = {
   'attach-shadow-constructor': attachShadowConstructor,
@@ -19,7 +20,8 @@ export const rules = {
   'no-invalid-element-name': noInvalidElementName,
   'no-self-class': noSelfClass,
   'no-typos': noTypos,
-  'require-listener-teardown': requireListenerTeardown
+  'require-listener-teardown': requireListenerTeardown,
+  'tag-name-matches-class': tagMatchesClass
 };
 
 export const configs = {

--- a/src/rules/tag-name-matches-class.ts
+++ b/src/rules/tag-name-matches-class.ts
@@ -1,0 +1,136 @@
+/**
+ * @fileoverview Enforces that the tag name of a custom element matches its
+ * class name
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {coerceArray} from '../util';
+import {toKebabCase} from '../util/text';
+
+/**
+ * Removes a set of prefixes and suffixes from a string if it contains them
+ * @param {string} str String to mutate
+ * @param {string[]} prefixes Prefixes to strip
+ * @param {string[]} suffixes Suffixes to strip
+ * @return {string}
+ */
+function removePrefixesAndSuffixes(
+  str: string,
+  prefixes: string[],
+  suffixes: string[]
+): string {
+  for (const prefix of prefixes) {
+    if (str.startsWith(prefix)) {
+      str = str.slice(prefix.length);
+    }
+  }
+  for (const suffix of suffixes) {
+    if (str.endsWith(suffix)) {
+      str = str.slice(0, -suffix.length);
+    }
+  }
+  return str;
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description:
+        'Enforces that the tag name of a custom element matches its class name',
+      url: 'https://github.com/43081j/eslint-plugin-wc/blob/master/docs/rules/tag-name-matches-class.md'
+    },
+    messages: {
+      nameMismatch:
+        'Custom element tag name should have been {expected} but was {actual}'
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          suffix: {
+            oneOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}]
+          },
+          prefix: {
+            oneOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}]
+          }
+        }
+      }
+    ]
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+    const suffixes = coerceArray(context.options[0]?.suffix ?? []);
+    const prefixes = coerceArray(context.options[0]?.prefix ?? []);
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      CallExpression: (node: ESTree.CallExpression): void => {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          ((node.callee.object.type === 'MemberExpression' &&
+            node.callee.object.object.type === 'Identifier' &&
+            node.callee.object.object.name === 'window' &&
+            node.callee.object.property.type === 'Identifier' &&
+            node.callee.object.property.name === 'customElements') ||
+            (node.callee.object.type === 'Identifier' &&
+              node.callee.object.name === 'customElements')) &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'define'
+        ) {
+          const [firstArg, secondArg] = node.arguments;
+
+          if (
+            firstArg &&
+            firstArg.type === 'Literal' &&
+            typeof firstArg.value === 'string' &&
+            (secondArg.type === 'Identifier' ||
+              secondArg.type === 'ClassExpression')
+          ) {
+            const tagName = firstArg.value;
+            const className =
+              secondArg.type === 'Identifier'
+                ? secondArg.name
+                : secondArg.id?.name;
+
+            if (!className) {
+              return;
+            }
+
+            const classNameWithoutPrefixesAndSuffixes =
+              removePrefixesAndSuffixes(className, prefixes, suffixes);
+            const expected = toKebabCase(classNameWithoutPrefixesAndSuffixes);
+
+            if (tagName !== expected) {
+              context.report({
+                node,
+                messageId: 'nameMismatch',
+                data: {
+                  expected,
+                  actual: tagName
+                }
+              });
+            }
+          }
+        }
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/test/rules/tag-name-matches-class_test.ts
+++ b/src/test/rules/tag-name-matches-class_test.ts
@@ -1,0 +1,196 @@
+/**
+ * @fileoverview Enforces that the tag name of a custom element matches its
+ * class name
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule from '../../rules/tag-name-matches-class';
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+ruleTester.run('tag-name-matches-class', rule, {
+  valid: [
+    'const x = 303;',
+    `fakeCustomElements.define('foo-bar', FewBor)`,
+    `customElements.define('foo-bar', FooBar)`,
+    `window.customElements.define('foo-bar', FooBar)`,
+    `customElements.define('foo-bar', class FooBar extends HTMLElement {})`,
+    `customElements.define(unknownConst, class FooBar extends HTMLElement {})`,
+    `customElements.define('foo-bar', class extends HTMLElement {})`,
+    {
+      code: `customElements.define('bar-baz', FooBarBaz);`,
+      options: [
+        {
+          prefix: ['Foo']
+        }
+      ]
+    },
+    {
+      code: `customElements.define('bar-baz', FooBarBaz);`,
+      options: [
+        {
+          prefix: 'Foo'
+        }
+      ]
+    },
+    {
+      code: `customElements.define('bar-baz', BarBaz);`,
+      options: [
+        {
+          prefix: ['Foo']
+        }
+      ]
+    },
+    {
+      code: `customElements.define('foo-bar', FooBarBaz);`,
+      options: [
+        {
+          suffix: ['Baz']
+        }
+      ]
+    },
+    {
+      code: `customElements.define('foo-bar', FooBarBaz);`,
+      options: [
+        {
+          suffix: 'Baz'
+        }
+      ]
+    },
+    {
+      code: `customElements.define('foo-bar', FooBar);`,
+      options: [
+        {
+          suffix: ['Baz']
+        }
+      ]
+    },
+    {
+      code: `customElements.define('hot-dogs', FooHotDogsBaz);`,
+      options: [
+        {
+          prefix: ['Foo'],
+          suffix: ['Baz']
+        }
+      ]
+    },
+    {
+      code: `customElements.define(
+        'bar-baz',
+        class FooBarBaz extends HTMLElement {}
+      );`,
+      options: [
+        {
+          prefix: ['Foo']
+        }
+      ]
+    }
+  ],
+
+  invalid: [
+    {
+      code: `customElements.define('foo-bar', CrazyElement)`,
+      errors: [
+        {
+          messageId: 'nameMismatch',
+          data: {
+            expected: 'crazy-element',
+            actual: 'foo-bar'
+          },
+          line: 1,
+          column: 1
+        }
+      ]
+    },
+    {
+      code: `customElements.define(
+        'foo-bar',
+        class CrazyElement extends HTMLElement {}
+      )`,
+      errors: [
+        {
+          messageId: 'nameMismatch',
+          data: {
+            expected: 'crazy-element',
+            actual: 'foo-bar'
+          },
+          line: 1,
+          column: 1
+        }
+      ]
+    },
+    {
+      code: `customElements.define('foo-bar', IceCreamBaz)`,
+      options: [
+        {
+          suffix: ['Baz']
+        }
+      ],
+      errors: [
+        {
+          messageId: 'nameMismatch',
+          data: {
+            expected: 'ice-cream',
+            actual: 'foo-bar'
+          },
+          line: 1,
+          column: 1
+        }
+      ]
+    },
+    {
+      code: `customElements.define('foo-bar', BazIceCream)`,
+      options: [
+        {
+          prefix: ['Baz']
+        }
+      ],
+      errors: [
+        {
+          messageId: 'nameMismatch',
+          data: {
+            expected: 'ice-cream',
+            actual: 'foo-bar'
+          },
+          line: 1,
+          column: 1
+        }
+      ]
+    },
+    {
+      code: `customElements.define('foo-bar', BazIceCreamBoz)`,
+      options: [
+        {
+          prefix: ['Baz'],
+          suffix: ['Boz']
+        }
+      ],
+      errors: [
+        {
+          messageId: 'nameMismatch',
+          data: {
+            expected: 'ice-cream',
+            actual: 'foo-bar'
+          },
+          line: 1,
+          column: 1
+        }
+      ]
+    }
+  ]
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -89,3 +89,12 @@ export function isNativeCustomElement(node: ESTree.Class): boolean {
     node.superClass.name === 'HTMLElement'
   );
 }
+
+/**
+ * Converts a literal-or-array value to an array value
+ * @param {unknown} val Value to convert
+ * @return {Array<unknown>}
+ */
+export function coerceArray<T>(val: T | T[]): T[] {
+  return Array.isArray(val) ? val : [val];
+}

--- a/src/util/text.ts
+++ b/src/util/text.ts
@@ -1,0 +1,11 @@
+/**
+ * Converts a string to kebab-case
+ * @param {string} str String to convert
+ * @return {string}
+ */
+export function toKebabCase(str: string): string {
+  return str
+    .replace(/([A-Z]($|[a-z]))/g, '-$1')
+    .replace(/^-/g, '')
+    .toLowerCase();
+}


### PR DESCRIPTION
Enforces that the tag name in `define(...)` matches the class name