### PR TITLE
feat (no-method-prefixed-with-on): new rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import noConstructorAttrs from './rules/no-constructor-attributes';
 import noConstructorParams from './rules/no-constructor-params';
 import noCustomizedBuiltInElements from './rules/no-customized-built-in-elements';
 import noInvalidElementName from './rules/no-invalid-element-name';
+import noOnPrefix from './rules/no-method-prefixed-with-on';
 import noSelfClass from './rules/no-self-class';
 import noTypos from './rules/no-typos';
 import recommended from './configs/recommended';
@@ -24,6 +25,7 @@ export const rules = {
   'no-constructor-params': noConstructorParams,
   'no-customized-built-in-elements': noCustomizedBuiltInElements,
   'no-invalid-element-name': noInvalidElementName,
+  'no-method-prefixed-with-on': noOnPrefix,
   'no-self-class': noSelfClass,
   'no-typos': noTypos,
   'require-listener-teardown': requireListenerTeardown,

--- a/src/rules/no-method-prefixed-with-on.ts
+++ b/src/rules/no-method-prefixed-with-on.ts
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview Disallows methods prefixed with `on`
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {isCustomElement} from '../util';
+import {getMethodName} from '../util/ast';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Disallows methods prefixed with `on`',
+      url: 'https://github.com/43081j/eslint-plugin-wc/blob/master/docs/rules/no-method-prefixed-with-on.md'
+    },
+    messages: {
+      noPrefix:
+        'Avoid using `on` as a prefix of method names as they can ' +
+        'easily conflict with reserved event handler names'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+    let insideElement = false;
+    const source = context.getSourceCode();
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (isCustomElement(context, node, source.getJSDocComment(node))) {
+          insideElement = true;
+        }
+      },
+      'ClassDeclaration,ClassExpression:exit': (): void => {
+        insideElement = false;
+      },
+      MethodDefinition: (node: ESTree.MethodDefinition): void => {
+        if (insideElement) {
+          const name = getMethodName(node);
+
+          if (name && name.startsWith('on')) {
+            context.report({
+              node,
+              messageId: 'noPrefix'
+            });
+          }
+        }
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/test/rules/no-method-prefixed-with-on_test.ts
+++ b/src/test/rules/no-method-prefixed-with-on_test.ts
@@ -1,0 +1,167 @@
+/**
+ * @fileoverview Disallows methods prefixed with `on`
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule from '../../rules/no-method-prefixed-with-on';
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+const parser = require.resolve('@typescript-eslint/parser');
+
+ruleTester.run('no-method-prefixed-with-on', rule, {
+  valid: [
+    'class A {}',
+    'const x = 303;',
+    {
+      code: `class A {
+        onFoo() {
+        }
+      }`
+    },
+    {
+      code: `class A extends B {
+        onFoo() {
+        }
+      }`
+    },
+    {
+      code: `class A {
+        onfoo() {
+        }
+      }`
+    },
+    {
+      code: `class A extends HTMLElement {
+        someMethod() {
+        }
+      }`
+    },
+    {
+      code: `class A extends HTMLElement {
+        [onSomethingButImAConst]() {
+        }
+      }`
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class A extends HTMLElement {
+        onFoo() {
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'noPrefix',
+          line: 2,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        onfoo() {
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'noPrefix',
+          line: 2,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `class A extends SomeElement {
+        onFoo() {
+        }
+      }`,
+      settings: {
+        wc: {
+          elementBaseClasses: ['SomeElement']
+        }
+      },
+      errors: [
+        {
+          messageId: 'noPrefix',
+          line: 2,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `/**
+       * @customElement
+       */
+      class A extends SomeElement {
+        onFoo() {
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'noPrefix',
+          line: 5,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `@customElement('x-foo')
+      class A extends SomeElement {
+        onFoo() {
+        }
+      }`,
+      parser,
+      errors: [
+        {
+          messageId: 'noPrefix',
+          line: 3,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        ['onFoo']() {
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'noPrefix',
+          line: 2,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `class A extends HTMLElement {
+        #onFoo() {
+        }
+      }`,
+      parser,
+      errors: [
+        {
+          messageId: 'noPrefix',
+          line: 2,
+          column: 9
+        }
+      ]
+    }
+  ]
+});

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -1,0 +1,21 @@
+import * as ESTree from 'estree';
+
+/**
+ * Computes the name of a given method node
+ * @param {ESTree.MethodDefinition} node Node to retrieve name from
+ * @return {string|null}
+ */
+export function getMethodName(node: ESTree.MethodDefinition): string | null {
+  if (
+    node.key.type === 'PrivateIdentifier' ||
+    (node.key.type === 'Identifier' && !node.computed)
+  ) {
+    return node.key.name;
+  }
+
+  if (node.key.type === 'Literal') {
+    return String(node.key.value);
+  }
+
+  return null;
+}


### PR DESCRIPTION
This disallows any method prefixed with `on` to avoid conflicts and/or confusion with built-on methods following the same convention.

cc @keithamus