### PR TITLE
feat (no-exports-with-element): new rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import noConstructor from './rules/no-constructor';
 import noConstructorAttrs from './rules/no-constructor-attributes';
 import noConstructorParams from './rules/no-constructor-params';
 import noCustomizedBuiltInElements from './rules/no-customized-built-in-elements';
+import noExports from './rules/no-exports-with-element';
 import noInvalidElementName from './rules/no-invalid-element-name';
 import noOnPrefix from './rules/no-method-prefixed-with-on';
 import noSelfClass from './rules/no-self-class';
@@ -30,6 +31,7 @@ export const rules = {
   'no-constructor-attributes': noConstructorAttrs,
   'no-constructor-params': noConstructorParams,
   'no-customized-built-in-elements': noCustomizedBuiltInElements,
+  'no-exports-with-element': noExports,
   'no-invalid-element-name': noInvalidElementName,
   'no-method-prefixed-with-on': noOnPrefix,
   'no-self-class': noSelfClass,

--- a/src/rules/define-tag-after-class-definition.ts
+++ b/src/rules/define-tag-after-class-definition.ts
@@ -9,6 +9,7 @@ import {Rule} from 'eslint';
 import * as ESTree from 'estree';
 import {isCustomElement} from '../util';
 import {isDefineCall} from '../util/customElements';
+import {resolveReference} from '../util/ast';
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -58,12 +59,9 @@ const rule: Rule.RuleModule = {
 
         if (isDefineCall(node)) {
           if (tagClass.type === 'Identifier') {
-            const ref = context
-              .getScope()
-              .references.find((r) => r.identifier.name === tagClass.name);
-
-            if (ref?.resolved && ref.resolved.defs.length === 1) {
-              seenClasses.delete(ref.resolved.defs[0].node);
+            const resolved = resolveReference(tagClass, context);
+            if (resolved) {
+              seenClasses.delete(resolved);
             }
           } else if (tagClass.type === 'ClassExpression') {
             seenClasses.delete(tagClass);

--- a/src/rules/expose-class-on-global.ts
+++ b/src/rules/expose-class-on-global.ts
@@ -7,6 +7,7 @@
 import {Rule} from 'eslint';
 import * as ESTree from 'estree';
 import {isCustomElement} from '../util';
+import {resolveReference} from '../util/ast';
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -62,13 +63,14 @@ const rule: Rule.RuleModule = {
           node.left.property.type === 'Identifier' &&
           node.right.type === 'Identifier'
         ) {
-          const className = node.right.name;
-          const ref = context
-            .getScope()
-            .references.find((r) => r.identifier.name === className);
-          if (ref?.resolved && ref.resolved.defs.length === 1) {
-            const classDef = ref.resolved.defs[0].node;
+          const classDef = resolveReference(node.right, context);
 
+          if (
+            classDef &&
+            (classDef.type === 'ClassExpression' ||
+              classDef.type === 'ClassDeclaration') &&
+            classDef.id
+          ) {
             seenClasses.delete(classDef);
 
             if (classDef.id.name !== node.left.property.name) {

--- a/src/rules/no-exports-with-element.ts
+++ b/src/rules/no-exports-with-element.ts
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview Disallows exports alongside custom element exports
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {isCustomElement} from '../util';
+import {resolveReference} from '../util/ast';
+
+const classSelector =
+  'ExportNamedDeclaration :matches(' +
+  'ClassDeclaration, ClassExpression, FunctionDeclaration)';
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Disallows exports alongside custom element exports',
+      url: 'https://github.com/43081j/eslint-plugin-wc/blob/master/docs/rules/no-exports-with-element.md'
+    },
+    messages: {
+      noExports:
+        'No additional exports should be defined when exporting a ' +
+        'custom element'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    const seenClasses = new Set<ESTree.Node>();
+    const exportedNodes = new Set<ESTree.Node>();
+    let hasElement = false;
+    const source = context.getSourceCode();
+
+    return {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (isCustomElement(context, node, source.getJSDocComment(node))) {
+          hasElement = true;
+          seenClasses.add(node);
+        }
+
+        // Allow classes which inherit `Event` since they're likely
+        // useful alongside the element
+        if (
+          node.superClass &&
+          node.superClass.type === 'Identifier' &&
+          node.superClass.name === 'Event'
+        ) {
+          seenClasses.add(node);
+        }
+      },
+      'ExportNamedDeclaration > VariableDeclaration > VariableDeclarator': (
+        node: ESTree.VariableDeclarator
+      ): void => {
+        if (node.init) {
+          exportedNodes.add(node.init);
+        }
+      },
+      'ExportNamedDeclaration ExportSpecifier': (
+        node: ESTree.ExportSpecifier
+      ): void => {
+        exportedNodes.add(node.local);
+      },
+      [classSelector]: (node: ESTree.Node): void => {
+        exportedNodes.add(node);
+      },
+      ExportDefaultDeclaration: (
+        node: ESTree.ExportDefaultDeclaration
+      ): void => {
+        let declaration = node.declaration;
+
+        if (declaration.type === 'AssignmentExpression') {
+          declaration = declaration.right;
+        }
+
+        exportedNodes.add(declaration);
+      },
+      'Program:exit': (): void => {
+        if (!hasElement) {
+          return;
+        }
+
+        for (const ref of exportedNodes) {
+          const node = resolveReference(ref, context);
+
+          if (seenClasses.has(node)) {
+            continue;
+          }
+
+          context.report({
+            node,
+            messageId: 'noExports'
+          });
+        }
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/test/rules/no-exports-with-element_test.ts
+++ b/src/test/rules/no-exports-with-element_test.ts
@@ -1,0 +1,169 @@
+/**
+ * @fileoverview Disallows exports alongside custom element exports
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+import rule from '../../rules/no-exports-with-element';
+import {RuleTester} from 'eslint';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+ruleTester.run('no-exports-with-element', rule, {
+  valid: [
+    'const x = 808;',
+    'export class Foo {}',
+    'export const x = 303;',
+    'export class Foo extends HTMLElement {}',
+    'class Foo extends HTMLElement {} export {Foo};',
+    'export const Foo = class extends HTMLElement {}',
+    `/** @customElement x-foo */
+    export class Foo extends Bar {}`,
+    `export class Foo extends HTMLElement {}
+    export class FooEvent extends Event {}`,
+    `class Foo extends HTMLElement {}
+    export default Foo`,
+    `export class Foo extends HTMLElement {}
+    export let bar;`,
+    `export class Foo extends HTMLElement {}
+    export default class Bar extends Event {}`,
+    `export class Foo extends HTMLElement {}
+    export default Bar = class extends Event {}`,
+    {
+      code: 'export class Foo extends Bar {}',
+      settings: {
+        wc: {
+          elementBaseClasses: ['Bar']
+        }
+      }
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+        export class Foo extends HTMLElement {}
+        export const bar = 303;
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 28,
+          messageId: 'noExports'
+        }
+      ]
+    },
+    {
+      code: `
+        export const bar = 303;
+        export class Foo extends HTMLElement {}
+      `,
+      errors: [
+        {
+          line: 2,
+          column: 28,
+          messageId: 'noExports'
+        }
+      ]
+    },
+    {
+      code: `
+        export class Foo extends HTMLElement {}
+        export class Bar extends Baz {}
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 16,
+          messageId: 'noExports'
+        }
+      ]
+    },
+    {
+      code: `
+        export class Foo extends HTMLElement {}
+        export class Bar {}
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 16,
+          messageId: 'noExports'
+        }
+      ]
+    },
+    {
+      code: `
+        export class Foo extends HTMLElement {}
+        export const Bar = class {};
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 28,
+          messageId: 'noExports'
+        }
+      ]
+    },
+    {
+      code: `
+        export class Foo extends HTMLElement {}
+        export function bar() {}
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 16,
+          messageId: 'noExports'
+        }
+      ]
+    },
+    {
+      code: `
+        export class Foo extends HTMLElement {}
+        const x = 5;
+        export {x};
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 15,
+          messageId: 'noExports'
+        }
+      ]
+    },
+    {
+      code: `
+        export class Foo extends HTMLElement {}
+        let bar;
+        export default bar = 303;
+      `,
+      errors: [
+        {
+          line: 4,
+          column: 30,
+          messageId: 'noExports'
+        }
+      ]
+    },
+    {
+      code: `
+        export class Foo extends HTMLElement {}
+        const bar = 303;
+        export default bar;
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 15,
+          messageId: 'noExports'
+        }
+      ]
+    }
+  ]
+});

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -1,4 +1,5 @@
 import * as ESTree from 'estree';
+import {Rule} from 'eslint';
 
 /**
  * Computes the name of a given method node
@@ -18,4 +19,30 @@ export function getMethodName(node: ESTree.MethodDefinition): string | null {
   }
 
   return null;
+}
+
+/**
+ * Attempts to resolve any references, e.g. if a node is an identifier
+ * @param {ESTree.Node} node Node to resolve
+ * @param {Rule.RuleContext} context Rule context
+ * @return {ESTree.Node}
+ */
+export function resolveReference(
+  node: ESTree.Node,
+  context: Rule.RuleContext
+): ESTree.Node {
+  if (node.type !== 'Identifier') {
+    return node;
+  }
+
+  const ref = context
+    .getSourceCode()
+    .getScope(node)
+    .references.find((r) => r.identifier.name === node.name);
+
+  if (ref?.resolved && ref.resolved.defs.length === 1) {
+    return ref.resolved.defs[0].node;
+  }
+
+  return node;
 }


### PR DESCRIPTION
Disallows exports alongside a custom element unless they're `Event` classes.

e.g.

```ts
// invalid
export class Foo extends HTMLElement {}
export const bar = 303;

// valid
export class Foo extends HTMLElement {}

// also valid
export class Foo extends HTMLElement {}
export class Bar extends Event {}
```

cc @keithamus