### PR TITLE
feat (no-invalid-extends): new rule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node-version: [14.x, 15.x, 16.x]
       fail-fast: false
     steps:
       - name: Checkout

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import noConstructorParams from './rules/no-constructor-params';
 import noCustomizedBuiltInElements from './rules/no-customized-built-in-elements';
 import noExports from './rules/no-exports-with-element';
 import noInvalidElementName from './rules/no-invalid-element-name';
+import noInvalidExtends from './rules/no-invalid-extends';
 import noOnPrefix from './rules/no-method-prefixed-with-on';
 import noSelfClass from './rules/no-self-class';
 import noTypos from './rules/no-typos';
@@ -33,6 +34,7 @@ export const rules = {
   'no-customized-built-in-elements': noCustomizedBuiltInElements,
   'no-exports-with-element': noExports,
   'no-invalid-element-name': noInvalidElementName,
+  'no-invalid-extends': noInvalidExtends,
   'no-method-prefixed-with-on': noOnPrefix,
   'no-self-class': noSelfClass,
   'no-typos': noTypos,

--- a/src/rules/no-invalid-extends.ts
+++ b/src/rules/no-invalid-extends.ts
@@ -1,0 +1,222 @@
+/**
+ * @fileoverview Disallows invalid class inheritance for custom elements
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {isCustomElement} from '../util';
+import {isDefineCall} from '../util/customElements';
+import {resolveReference} from '../util/ast';
+import {builtInTagClassMap} from '../util/tag-names';
+
+/**
+ * Computes the `extends` option from a `customElements.define` third
+ * argument.
+ * @param {ESTree.Node} node Node to compute value for
+ * @return {string|null}
+ */
+function getExtendsOption(node: ESTree.Node): string | null {
+  if (node.type !== 'ObjectExpression') {
+    return null;
+  }
+
+  const extendsOption = node.properties.find(
+    (prop): prop is ESTree.Property =>
+      prop.type === 'Property' &&
+      ((prop.key.type === 'Literal' && prop.key.value === 'extends') ||
+        (prop.key.type === 'Identifier' && prop.key.name === 'extends'))
+  );
+
+  if (!extendsOption) {
+    return null;
+  }
+
+  const value = extendsOption.value;
+
+  if (value.type === 'Literal') {
+    return String(value.value);
+  }
+
+  if (value.type === 'TemplateLiteral' && value.expressions.length === 0) {
+    return value.quasis.map((quasi) => quasi.value.raw).join('');
+  }
+
+  return null;
+}
+
+const formatter = new Intl.ListFormat('en', {
+  style: 'short',
+  type: 'disjunction'
+});
+
+/**
+ * Formats a set of names to be human-readable
+ * @param {Iterable<string>} names Names to format
+ * @return {string}
+ */
+function formatNames(names: Iterable<string>): string {
+  return formatter.format(names);
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Disallows invalid class inheritance for custom elements',
+      url: 'https://github.com/43081j/eslint-plugin-wc/blob/master/docs/rules/no-invalid-extends.md'
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          allowedSuperNames: {
+            type: 'array',
+            items: {type: 'string'}
+          }
+        }
+      }
+    ],
+    messages: {
+      invalid: 'Custom element must extend {allowedSuperNames}',
+      invalidOrMissingExtends:
+        'Custom element must extend {allowedSuperNames}, or pass ' +
+        "{extends: '{extendsProp}'} as a third argument to `define`",
+      invalidExtends:
+        'Custom element extends {superName} but the definition includes ' +
+        "{extends: '{actualExtends}'}. Either the element must extend " +
+        '{allowedSuperNames} or the definition must include ' +
+        "{extends: '{expectedExtends}'}.",
+      unknownExtends:
+        'Custom element extends {superName} but the definition includes ' +
+        "{extends: '{actualExtends}'}, which is an unknown built-in. " +
+        'You should probably remove the `extends` option.'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    const source = context.getSourceCode();
+    const elementClasses = new Set<ESTree.Class>();
+    const userAllowedSuperNames = context.options[0]?.allowedSuperNames ?? [];
+
+    return {
+      'ClassExpression,ClassDeclaration': (node: ESTree.Class): void => {
+        if (isCustomElement(context, node, source.getJSDocComment(node))) {
+          elementClasses.add(node);
+        }
+      },
+      CallExpression: (node: ESTree.CallExpression): void => {
+        if (!isDefineCall(node) || node.arguments.length < 2) {
+          return;
+        }
+
+        const [, arg1, arg2] = node.arguments;
+        const classRef = resolveReference(arg1, context);
+
+        if (
+          !classRef ||
+          (classRef.type !== 'ClassExpression' &&
+            classRef.type !== 'ClassDeclaration') ||
+          !elementClasses.has(classRef)
+        ) {
+          return;
+        }
+
+        const extendsTag = arg2 && getExtendsOption(arg2);
+        let allowedSuperNames: Set<string>;
+
+        if (
+          extendsTag !== null &&
+          builtInTagClassMap[extendsTag as keyof HTMLElementTagNameMap]
+        ) {
+          allowedSuperNames = new Set<string>([
+            builtInTagClassMap[extendsTag as keyof HTMLElementTagNameMap]
+          ]);
+        } else {
+          allowedSuperNames = new Set<string>(userAllowedSuperNames);
+          allowedSuperNames.add('HTMLElement');
+        }
+
+        const formattedSuperNames = formatNames(allowedSuperNames);
+
+        if (!classRef.superClass) {
+          context.report({
+            node,
+            messageId: 'invalid',
+            data: {
+              allowedSuperNames: formattedSuperNames
+            }
+          });
+          return;
+        }
+
+        // We can't handle funky subclasses, like mixins and other such
+        // chaos
+        if (classRef.superClass.type !== 'Identifier') {
+          return;
+        }
+
+        const superName = classRef.superClass.name;
+
+        if (!allowedSuperNames.has(superName)) {
+          const expectedExtends = Object.entries(builtInTagClassMap).find(
+            (entry) => entry[1] === superName
+          )?.[0];
+
+          if (extendsTag && !expectedExtends) {
+            // the class extends something that isn't built-in, but specifies
+            // an `extends`
+            context.report({
+              node,
+              messageId: 'unknownExtends',
+              data: {
+                allowedSuperNames: formattedSuperNames,
+                superName,
+                actualExtends: extendsTag
+              }
+            });
+          } else if (!extendsTag && expectedExtends) {
+            // the class inherits a built-in but doesn't specify `extends`
+            context.report({
+              node,
+              messageId: 'invalidOrMissingExtends',
+              data: {
+                allowedSuperNames: formattedSuperNames,
+                expectedExtends
+              }
+            });
+          } else if (
+            extendsTag &&
+            extendsTag !== expectedExtends &&
+            expectedExtends
+          ) {
+            // the class inherits a built-in and specifies `extends`, but it
+            // is the wrong value
+            context.report({
+              node,
+              messageId: 'invalidExtends',
+              data: {
+                actualExtends: extendsTag,
+                expectedExtends,
+                allowedSuperNames: formattedSuperNames,
+                superName
+              }
+            });
+          } else {
+            // the class extends some non-built-in class we don't allow
+            context.report({
+              node,
+              messageId: 'invalid',
+              data: {
+                allowedSuperNames: formattedSuperNames
+              }
+            });
+          }
+        }
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/test/rules/no-invalid-extends_test.ts
+++ b/src/test/rules/no-invalid-extends_test.ts
@@ -1,0 +1,344 @@
+/**
+ * @fileoverview Disallows invalid class inheritance for custom elements
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule from '../../rules/no-invalid-extends';
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+const parser = require.resolve('@typescript-eslint/parser');
+
+ruleTester.run('no-invalid-extends', rule, {
+  valid: [
+    'const x = 808;',
+    'class Foo {}',
+    'class Foo extends HTMLElement {}',
+    'someOtherCallExpr()',
+    'customElements.define(nonsense)',
+    `customElements.define('a', unresolveable)`,
+    `customElements.define('a', unresolveable, {extends: 'div'})`,
+    `const x = 303; customElements.define('a', x);`,
+    {
+      code: `class A extends HTMLElement {}
+        customElements.define('a', A);`
+    },
+    {
+      code: `class A {}
+        customElements.define('a', A);`
+    },
+    {
+      code: `/** @customElement */
+        class A extends Complex(Nonsense()) {}
+        customElements.define('a', A);`
+    },
+    {
+      code: `customElements.define('a', class A extends HTMLElement {})`
+    },
+    {
+      code: `customElements.define(
+        'a',
+        /** customElement */ class A extends HTMLDivElement {},
+        {extends: 'div'}
+      )`
+    },
+    {
+      code: `customElements.define(
+        'a',
+        /** customElement */ class A extends HTMLDivElement {},
+        {extends: \`div\`}
+      )`
+    },
+    {
+      code: `/** @customElement */
+        class A extends HTMLDivElement {}
+        customElements.define('a', A, {extends: 'div'});`
+    },
+    {
+      code: `/** @customElement */
+        class A extends HTMLDivElement {}
+        customElements.define('a', A, {'extends': 'div'});`
+    },
+    {
+      code: `
+        /**
+         * @customElement
+         */
+        class A extends SomeElement {}
+        customElements.define('a', A);
+      `,
+      options: [
+        {
+          allowedSuperNames: ['SomeElement']
+        }
+      ]
+    },
+    {
+      code: `class A extends SomeElement {}
+      customElements.define('a', A);`,
+      settings: {
+        wc: {
+          elementBaseClasses: ['SomeElement']
+        }
+      },
+      options: [
+        {
+          allowedSuperNames: ['SomeElement']
+        }
+      ]
+    },
+    {
+      code: `class A extends SomeElement {}
+      customElements.define('a', A);`,
+      settings: {
+        wc: {
+          elementBaseClasses: ['SomeElement', 'SomeOtherElement']
+        }
+      },
+      options: [
+        {
+          allowedSuperNames: ['SomeElement', 'SomeOtherElement']
+        }
+      ]
+    },
+    {
+      code: `@customElement('x-foo')
+      class A extends SomeElement {}`,
+      parser
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+        /** @customElement */
+        class Foo {}
+        customElements.define('foo', Foo);
+      `,
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 4,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLElement'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        /** @customElement */
+        class Foo extends Bar {}
+        customElements.define('foo', Foo, {extends: 'nonsense'});
+      `,
+      errors: [
+        {
+          messageId: 'unknownExtends',
+          line: 4,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLElement',
+            superName: 'Bar',
+            actualExtends: 'nonsense'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        /** @customElement */
+        class Foo extends Bar {}
+        customElements.define('foo', Foo, {extends: 'div'});
+      `,
+      errors: [
+        {
+          messageId: 'unknownExtends',
+          line: 4,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLElement',
+            superName: 'Bar',
+            actualExtends: 'nonsense'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        /** @customElement */
+        class Foo extends Bar {}
+        customElements.define('foo', Foo, {extends: \`div\`});
+      `,
+      errors: [
+        {
+          messageId: 'unknownExtends',
+          line: 4,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLElement',
+            superName: 'Bar',
+            actualExtends: 'nonsense'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        /** @customElement */
+        class Foo extends Bar {}
+        customElements.define('foo', Foo);
+      `,
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 4,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLElement'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        /** @customElement */
+        class Foo extends Bar {}
+        customElements.define('foo', Foo);
+      `,
+      options: [
+        {
+          allowedSuperNames: ['SomeElement']
+        }
+      ],
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 4,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLElement, SomeElement'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        /** @customElement */
+        class Foo extends Bar {}
+        customElements.define('foo', Foo);
+      `,
+      options: [
+        {
+          allowedSuperNames: ['SomeElement', 'SomeOtherElement']
+        }
+      ],
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 4,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLElement, SomeElement or SomeOtherElement'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        /** @customElement */
+        class Foo extends HTMLDivElement {}
+        customElements.define('foo', Foo);
+      `,
+      errors: [
+        {
+          messageId: 'invalidOrMissingExtends',
+          line: 4,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLDivElement',
+            expectedExtends: 'div'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        /** @customElement */
+        class Foo extends HTMLDivElement {}
+        customElements.define('foo', Foo, {extends: 'span'});
+      `,
+      errors: [
+        {
+          messageId: 'invalidExtends',
+          line: 4,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLDivElement',
+            expectedExtends: 'div'
+          }
+        }
+      ]
+    },
+    {
+      code: `/** @customElement */
+        class Foo extends Bar {}
+        customElements.define('foo', Foo, unresolveable);`,
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 3,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLElement'
+          }
+        }
+      ]
+    },
+    {
+      code: `/** @customElement */
+        class Foo extends Bar {}
+        customElements.define('foo', Foo, {});`,
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 3,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLElement'
+          }
+        }
+      ]
+    },
+    {
+      code: `/** @customElement */
+        class Foo extends Bar {}
+        customElements.define('foo', Foo, {extends: unresolveable});`,
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 3,
+          column: 9,
+          data: {
+            allowedSuperNames: 'HTMLElement'
+          }
+        }
+      ]
+    }
+  ]
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2021",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",


### PR DESCRIPTION
Enforces that custom elements extend from a list of allowed classes.

By default, the only allowed class is `HTMLElement` unless you use the `extends` option when defining the element. In those cases, it must extend the known built-in class (e.g. HTMLDivElement).

For example:

```ts
// invalid

/** @customElement */
class Foo extends Bar {}
customElements.define('foo', Foo);

// valid

/** @customElement */
class Foo extends HTMLElement {}
customElements.define('foo', Foo);

// also valid

/** @customElement */
class Foo extends HTMLDivElement {}
customElements.define('foo', Foo, {extends: 'div'});

// also invalid

/** @customElement */
class Foo extends HTMLDivElement {}
customElements.define('foo', Foo);
```

cc @keithamus