### PR TITLE
feat (file-name-matches-element): new rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import attachShadowConstructor from './rules/attach-shadow-constructor';
 import bestPractice from './configs/best-practice';
+import filenameMatches from './rules/file-name-matches-element';
 import guardDefine from './rules/guard-define-call';
 import guardSuperCall from './rules/guard-super-call';
 import maxElementsPerFile from './rules/max-elements-per-file';
@@ -22,6 +23,7 @@ import tagMatchesClass from './rules/tag-name-matches-class';
 
 export const rules = {
   'attach-shadow-constructor': attachShadowConstructor,
+  'file-name-matches-element': filenameMatches,
   'guard-define': guardDefine,
   'guard-super-call': guardSuperCall,
   'max-elements-per-file': maxElementsPerFile,

--- a/src/rules/file-name-matches-element.ts
+++ b/src/rules/file-name-matches-element.ts
@@ -1,0 +1,197 @@
+/**
+ * @fileoverview Enforces that the filename of a file containing an element
+ * matches that of its class name
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {isCustomElement, coerceArray} from '../util';
+import * as path from 'path';
+import {toCaseByType} from '../util/text';
+
+/**
+ * Computes a set of prefixed/suffixed names for a given name
+ * @param {string} name Name to generate names for
+ * @param {Iterable<string>} prefixes Prefixes to apply
+ * @param {Iterable<string>} suffixes Suffixes to apply
+ */
+function* computeNames(
+  name: string,
+  prefixes: Iterable<string>,
+  suffixes: Iterable<string>
+): Generator<string> {
+  const lowerName = name.toLowerCase();
+
+  for (const prefix of prefixes) {
+    if (lowerName.startsWith(prefix.toLowerCase())) {
+      const truncated = name.slice(prefix.length);
+      yield truncated;
+
+      for (const suffix of suffixes) {
+        if (truncated.toLowerCase().endsWith(suffix.toLowerCase())) {
+          yield truncated.slice(0, truncated.length - suffix.length);
+        }
+      }
+    }
+  }
+
+  for (const suffix of suffixes) {
+    if (lowerName.endsWith(suffix.toLowerCase())) {
+      const truncated = name.slice(0, name.length - suffix.length);
+      yield truncated;
+
+      for (const prefix of prefixes) {
+        if (truncated.toLowerCase().startsWith(prefix.toLowerCase())) {
+          yield truncated.slice(prefix.length);
+        }
+      }
+    }
+  }
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description:
+        'Enforces that the filename of a file containing an element' +
+        'matches that of its class name',
+      url: 'https://github.com/43081j/eslint-plugin-wc/blob/master/docs/rules/file-name-matches-element.md'
+    },
+    messages: {
+      fileMismatch: 'File name should be "{{expected}}" but was "{{actual}}"'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          transform: {
+            oneOf: [
+              {
+                enum: ['none', 'snake', 'kebab', 'pascal', 'camel']
+              },
+              {
+                type: 'array',
+                items: {
+                  enum: ['none', 'snake', 'kebab', 'pascal', 'camel']
+                },
+                minItem: 1,
+                maxItems: 4
+              }
+            ]
+          },
+          prefix: {
+            oneOf: [
+              {
+                type: 'string'
+              },
+              {
+                type: 'array',
+                items: {
+                  type: 'string'
+                }
+              }
+            ]
+          },
+          suffix: {
+            oneOf: [
+              {
+                type: 'string'
+              },
+              {
+                type: 'array',
+                items: {
+                  type: 'string'
+                }
+              }
+            ]
+          },
+          matchDirectory: {
+            type: 'boolean'
+          }
+        }
+      }
+    ]
+  },
+
+  create(context): Rule.RuleListener {
+    const source = context.getSourceCode();
+    const options = context.options?.[0] ?? {};
+    const userSuffixes = coerceArray(options.suffix ?? []);
+    const userPrefixes = coerceArray(options.prefix ?? []);
+    const transforms = coerceArray(options.transform ?? ['kebab', 'camel']);
+    const matchDirectory = options.matchDirectory === true;
+
+    const filename = context.getFilename();
+
+    // We don't want to match stdin and what not
+    if (!filename || filename === '<input>' || filename === '<text>') {
+      return {};
+    }
+
+    return {
+      'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {
+        if (!isCustomElement(context, node, source.getJSDocComment(node))) {
+          return;
+        }
+
+        if (!node.id) {
+          return;
+        }
+
+        const className = node.id.name;
+        const normalisedFilename = path.basename(
+          filename,
+          path.extname(filename)
+        );
+        const names = new Set<string>([className]);
+        const prefixes = new Set<string>(userPrefixes);
+        const suffixes = new Set<string>(userSuffixes);
+
+        if (matchDirectory) {
+          const fileDir = path.dirname(filename);
+          const parts = fileDir.toLowerCase().split(path.sep);
+
+          while (parts.length) {
+            prefixes.add(parts.join(''));
+            parts.shift();
+          }
+        }
+
+        for (const possibleName of computeNames(
+          className,
+          prefixes,
+          suffixes
+        )) {
+          names.add(possibleName);
+        }
+
+        const allowedFileNames = new Set<string>();
+
+        for (const possibleName of names) {
+          for (const transform of transforms) {
+            allowedFileNames.add(toCaseByType(possibleName, transform));
+          }
+        }
+
+        if (
+          allowedFileNames.size > 0 &&
+          !allowedFileNames.has(normalisedFilename)
+        ) {
+          const allowedNames = [...allowedFileNames].join('" or "');
+          context.report({
+            node: node.id,
+            messageId: 'fileMismatch',
+            data: {
+              expected: allowedNames,
+              actual: normalisedFilename
+            }
+          });
+        }
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/test/rules/file-name-matches-element_test.ts
+++ b/src/test/rules/file-name-matches-element_test.ts
@@ -1,0 +1,303 @@
+/**
+ * @fileoverview Enforces that the filename of a file containing an element
+ * matches that of its class name
+ * @author James Garbutt <https://github.com/43081j>
+ * @author Keith Cirkel <https://github.com/keithamus>
+ */
+
+import rule from '../../rules/file-name-matches-element';
+import {RuleTester} from 'eslint';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+ruleTester.run('file-name-matches-element', rule, {
+  valid: [
+    {
+      code: 'const x = 808;',
+      filename: 'foo.js'
+    },
+    {
+      code: 'class UnrelatedClass {}',
+      filename: 'foo.js'
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: '<input>'
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: '<text>'
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: ''
+    },
+    {
+      code: `const x = class extends HTMLElement {};`,
+      filename: 'foo.js'
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: 'suspicious.js',
+      options: [
+        {
+          transform: []
+        }
+      ]
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: 'some-element.js'
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: 'someElement.js'
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: 'SomeElement.js',
+      options: [
+        {
+          transform: ['pascal']
+        }
+      ]
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: 'SomeElement.js',
+      options: [
+        {
+          transform: 'pascal'
+        }
+      ]
+    },
+    {
+      code: 'class FooSomeElement extends HTMLElement {}',
+      filename: 'someElement.js',
+      options: [
+        {
+          prefix: 'Foo'
+        }
+      ]
+    },
+    {
+      code: 'class FooSomeElement extends HTMLElement {}',
+      filename: 'fooSomeElement.js',
+      options: [
+        {
+          prefix: 'Foo'
+        }
+      ]
+    },
+    {
+      code: 'class FooSomeElement extends HTMLElement {}',
+      filename: 'someElement.js',
+      options: [
+        {
+          prefix: ['Foo']
+        }
+      ]
+    },
+    {
+      code: 'class SomeElementFoo extends HTMLElement {}',
+      filename: 'someElement.js',
+      options: [
+        {
+          suffix: 'Foo'
+        }
+      ]
+    },
+    {
+      code: 'class SomeElementFoo extends HTMLElement {}',
+      filename: 'someElementFoo.js',
+      options: [
+        {
+          suffix: 'Foo'
+        }
+      ]
+    },
+    {
+      code: 'class SomeElementFoo extends HTMLElement {}',
+      filename: 'someElement.js',
+      options: [
+        {
+          suffix: ['Foo']
+        }
+      ]
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: 'src/foo/someElement.js',
+      options: [
+        {
+          matchDirectory: true
+        }
+      ]
+    },
+    {
+      code: 'class BarSomeElement extends HTMLElement {}',
+      filename: 'foo/bar/someElement.js',
+      options: [
+        {
+          matchDirectory: true
+        }
+      ]
+    },
+    {
+      code: 'class FooBarSomeElement extends HTMLElement {}',
+      filename: 'foo/bar/someElement.js',
+      options: [
+        {
+          matchDirectory: true
+        }
+      ]
+    },
+    {
+      code: 'class FooSomeElementBar extends HTMLElement {}',
+      filename: 'someElement.js',
+      options: [
+        {
+          prefix: 'Foo',
+          suffix: 'Bar'
+        }
+      ]
+    },
+    {
+      code: 'class SomeElementBar extends HTMLElement {}',
+      filename: 'someElement.js',
+      options: [
+        {
+          prefix: 'Foo',
+          suffix: 'Bar'
+        }
+      ]
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: 'someElement.js',
+      options: [
+        {
+          prefix: 'Foo',
+          suffix: 'Bar'
+        }
+      ]
+    },
+    {
+      code: 'class FooSomeElement extends HTMLElement {}',
+      filename: 'someElement.js',
+      options: [
+        {
+          prefix: 'Foo',
+          suffix: 'Bar'
+        }
+      ]
+    }
+  ],
+
+  invalid: [
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: 'gibberish.js',
+      errors: [
+        {
+          line: 1,
+          column: 7,
+          messageId: 'fileMismatch',
+          data: {
+            expected: 'some-element" or "someElement',
+            actual: 'gibberish'
+          }
+        }
+      ]
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: 'someElement.js',
+      options: [
+        {
+          transform: 'snake'
+        }
+      ],
+      errors: [
+        {
+          line: 1,
+          column: 7,
+          messageId: 'fileMismatch',
+          data: {
+            expected: 'some_element',
+            actual: 'someElement'
+          }
+        }
+      ]
+    },
+    {
+      code: 'class FooSomeElement extends HTMLElement {}',
+      filename: 'barSomeElement.js',
+      options: [
+        {
+          prefix: 'Foo'
+        }
+      ],
+      errors: [
+        {
+          line: 1,
+          column: 7,
+          messageId: 'fileMismatch',
+          data: {
+            expected:
+              'foo-some-element" or "fooSomeElement" or ' +
+              '"some-element" or "someElement',
+            actual: 'barSomeElement'
+          }
+        }
+      ]
+    },
+    {
+      code: 'class SomeElementFoo extends HTMLElement {}',
+      filename: 'someElementBar.js',
+      options: [
+        {
+          suffix: 'Foo'
+        }
+      ],
+      errors: [
+        {
+          line: 1,
+          column: 7,
+          messageId: 'fileMismatch',
+          data: {
+            expected:
+              'some-element-foo" or "someElementFoo" or ' +
+              '"some-element" or "someElement',
+            actual: 'someElementBar'
+          }
+        }
+      ]
+    },
+    {
+      code: 'class BarSomeElement extends HTMLElement {}',
+      filename: 'foo/someElement.js',
+      options: [
+        {
+          matchDirectory: true
+        }
+      ],
+      errors: [
+        {
+          line: 1,
+          column: 7,
+          messageId: 'fileMismatch',
+          data: {
+            expected: 'bar-some-element" or "barSomeElement',
+            actual: 'someElement'
+          }
+        }
+      ]
+    }
+  ]
+});

--- a/src/test/util/text_test.ts
+++ b/src/test/util/text_test.ts
@@ -1,0 +1,60 @@
+import * as text from '../../util/text';
+import {expect} from 'chai';
+
+describe('text utils', () => {
+  describe('toKebabCase', () => {
+    it('should convert strings to kebab-case', () => {
+      expect(text.toKebabCase('foobar')).to.equal('foobar');
+      expect(text.toKebabCase('fooBar')).to.equal('foo-bar');
+      expect(text.toKebabCase('FooBar')).to.equal('foo-bar');
+      expect(text.toKebabCase('AfooBfooC')).to.equal('afoo-bfoo-c');
+    });
+  });
+
+  describe('toSnakeCase', () => {
+    it('should convert strings to snake_case', () => {
+      expect(text.toSnakeCase('foobar')).to.equal('foobar');
+      expect(text.toSnakeCase('fooBar')).to.equal('foo_bar');
+      expect(text.toSnakeCase('FooBar')).to.equal('foo_bar');
+      expect(text.toSnakeCase('AfooBfooC')).to.equal('afoo_bfoo_c');
+    });
+  });
+
+  describe('toPascalCase', () => {
+    it('should convert strings to PascalCase', () => {
+      expect(text.toPascalCase('foobar')).to.equal('Foobar');
+      expect(text.toPascalCase('fooBar')).to.equal('FooBar');
+      expect(text.toPascalCase('FooBar')).to.equal('FooBar');
+      expect(text.toPascalCase('AfooBfooC')).to.equal('AfooBfooC');
+      expect(text.toPascalCase('')).to.equal('');
+    });
+  });
+
+  describe('toCamelCase', () => {
+    it('should convert strings to camelCase', () => {
+      expect(text.toCamelCase('foobar')).to.equal('foobar');
+      expect(text.toCamelCase('fooBar')).to.equal('fooBar');
+      expect(text.toCamelCase('FooBar')).to.equal('fooBar');
+      expect(text.toCamelCase('AfooBfooC')).to.equal('afooBfooC');
+      expect(text.toCamelCase('')).to.equal('');
+    });
+  });
+
+  describe('toCaseByType', () => {
+    it('should convert to kebab case with type=kebab', () => {
+      expect(text.toCaseByType('fooBar', 'kebab')).to.equal('foo-bar');
+    });
+
+    it('should convert to camel case with type=camel', () => {
+      expect(text.toCaseByType('FooBar', 'camel')).to.equal('fooBar');
+    });
+
+    it('should convert to snake case with type=snake', () => {
+      expect(text.toCaseByType('fooBar', 'snake')).to.equal('foo_bar');
+    });
+
+    it('should convert to pascal case with type=pascal', () => {
+      expect(text.toCaseByType('fooBar', 'pascal')).to.equal('FooBar');
+    });
+  });
+});

--- a/src/util/text.ts
+++ b/src/util/text.ts
@@ -1,5 +1,5 @@
 /**
- * Converts a string to kebab-case
+ * Converts a _spaceless_ string to kebab-case
  * @param {string} str String to convert
  * @return {string}
  */
@@ -8,4 +8,62 @@ export function toKebabCase(str: string): string {
     .replace(/([A-Z]($|[a-z]))/g, '-$1')
     .replace(/^-/g, '')
     .toLowerCase();
+}
+
+/**
+ * Converts a _spaceless_ string to snake_case
+ * @param {string} str String to convert
+ * @return {string}
+ */
+export function toSnakeCase(str: string): string {
+  return str
+    .replace(/([A-Z]($|[a-z]))/g, '_$1')
+    .replace(/^_/g, '')
+    .toLowerCase();
+}
+
+/**
+ * Converts a _spaceless_ string to PascalCase
+ * @param {string} str String to convert
+ * @return {string}
+ */
+export function toPascalCase(str: string): string {
+  if (str.length === 0) {
+    return str;
+  }
+  return str[0].toUpperCase() + str.slice(1);
+}
+
+/**
+ * Converts a _spaceless_ string to camelCase
+ * @param {string} str String to convert
+ * @return {string}
+ */
+export function toCamelCase(str: string): string {
+  if (str.length === 0) {
+    return str;
+  }
+  return str[0].toLowerCase() + str.slice(1);
+}
+
+/**
+ * Converts a _spaceless_ string to the specified type of casing
+ * @param {string} str String to convert
+ * @param {string} type Type of casing
+ * @return {string}
+ */
+export function toCaseByType(
+  str: string,
+  type: 'kebab' | 'camel' | 'snake' | 'pascal'
+): string {
+  switch (type) {
+    case 'kebab':
+      return toKebabCase(str);
+    case 'camel':
+      return toCamelCase(str);
+    case 'snake':
+      return toSnakeCase(str);
+    case 'pascal':
+      return toPascalCase(str);
+  }
 }


### PR DESCRIPTION
Enforces that the filename of a file containing a custom element matches its class name according to the configured conventions.

For example, the default is `['kebab', 'camel']` which means the following examples are true:

```ts
// valid filename: someElement.js
// invalid filename: some_element.js
class SomeElement extends HTMLElement {}
```

With `matchDirectory: true` set:

```ts
// valid filename: foo/bar/someElement.js
// valid filename: bar/someElement.js
// valid filename: fooBarSomeElement.js
// invalid filename: some_element.js
class FooBarSomeElement extends HTMLElement {}
```

cc @keithamus this was probably the most difficult one. its not a lot of logic but getting my head around the various nested pieces of logic took a while 😂 

but its the last one! 🎉 