### PR TITLE
fix (expose-class-on-global): allow named class expressions

### DIFF
--- a/src/test/rules/expose-class-on-global_test.ts
+++ b/src/test/rules/expose-class-on-global_test.ts
@@ -46,10 +46,21 @@ ruleTester.run('expose-class-on-global', rule, {
           elementBaseClasses: ['Bar']
         }
       }
-    }
+    },
+    'window.Foo = class Foo extends HTMLElement {}'
   ],
 
   invalid: [
+    {
+      code: `window.Foo = class extends HTMLElement {}`,
+      errors: [
+        {
+          messageId: 'sameName',
+          line: 1,
+          column: 1
+        }
+      ]
+    },
     {
       code: `class Foo extends HTMLElement {}`,
       errors: [


### PR DESCRIPTION
This changes the rule to allow:

```ts
window.Foo = class Foo extends HTMLElement {};
```

Which will then still disallow:

```ts
window.Foo = class extends HTMLElement {};
```

cc @keithamus this seems to align it to your docs then. can you let me know if this is what behaviour you expected?