### PR TITLE
chore (no-invalid-element-name): update readme with new options

### DIFF
--- a/docs/rules/no-invalid-element-name.md
+++ b/docs/rules/no-invalid-element-name.md
@@ -16,13 +16,15 @@ customElements.define('app', class extends HTMLElement {});
 customElements.define('1-app', class extends HTMLElement {});
 customElements.define('-app', class extends HTMLElement {});
 customElements.define('my-app!', class extends HTMLElement {});
+customElements.define('my-app-', class extends HTMLElement {});
+customElements.define('my--app', class extends HTMLElement {});
+
+/* disallowNamespaces: true */
 customElements.define('font-face', class extends HTMLElement {});
 customElements.define('polymer-app', class extends HTMLElement {});
 customElements.define('x-app', class extends HTMLElement {});
 customElements.define('ng-app', class extends HTMLElement {});
 customElements.define('xml-app', class extends HTMLElement {});
-customElements.define('my-app-', class extends HTMLElement {});
-customElements.define('my--app', class extends HTMLElement {});
 ```
 
 The following patterns are not warnings:
@@ -30,14 +32,19 @@ The following patterns are not warnings:
 ```ts
 customElements.define('my-app', class extends HTMLElement {});
 
-// { loose: true }
+/* disallowNamespaces: false (default) */
 customElements.define('polymer-app', class extends HTMLElement {});
-customElements.define('x-app', class extends HTMLElement {});
-customElements.define('ng-app', class extends HTMLElement {});
-customElements.define('xml-app', class extends HTMLElement {});
-customElements.define('my-app-', class extends HTMLElement {});
-customElements.define('my--app', class extends HTMLElement {});
 ```
+
+### Options
+
+- `onlyAlphanum` (default: `false`) can be set to only allow alpha-numeric names
+- `disallowNamespaces` (default: `false`) can be set to disallow well known
+namespaces (e.g. `polymer-`)
+- `suffix` (default: `[]`) can be set to an array of required suffixes the name
+must contain one of
+- `prefix` (default: `[]`) can be set to an array of required prefixes the name
+must contain one of
 
 ## When Not To Use It
 


### PR DESCRIPTION
New options have been added:

- `onlyAlphanum`
- `disallowNamespaces` (which replaces `loose` but the default is flipped)
- `suffix` (an array of required suffixes)
- `prefix` (an array of required prefixes)

cc @keithamus