### PR TITLE
feat: add LitElement to recommended config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-wc",
-  "version": "2.0.0",
+  "version": "2.0.1-lit.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-wc",
-      "version": "2.0.0",
+      "version": "2.0.1-lit.0",
       "license": "MIT",
       "dependencies": {
         "is-valid-element-name": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-wc",
-  "version": "2.0.0",
+  "version": "2.0.1-lit.0",
   "description": "ESLint plugin for Web Components",
   "main": "lib/index.js",
   "files": [

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -3,11 +3,6 @@ const config = {
   parserOptions: {
     sourceType: 'module'
   },
-  settings: {
-    wc: {
-      elementBaseClasses: ['LitElement']
-    }
-  },
 
   rules: {
     'wc/no-constructor-attributes': 'error',

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -3,6 +3,11 @@ const config = {
   parserOptions: {
     sourceType: 'module'
   },
+  settings: {
+    wc: {
+      elementBaseClasses: ['LitElement']
+    }
+  },
 
   rules: {
     'wc/no-constructor-attributes': 'error',

--- a/src/rules/no-invalid-extends.ts
+++ b/src/rules/no-invalid-extends.ts
@@ -6,7 +6,7 @@
 
 import {Rule} from 'eslint';
 import * as ESTree from 'estree';
-import {isCustomElement} from '../util';
+import {isCustomElement, getElementBaseClasses} from '../util';
 import {isDefineCall} from '../util/customElements';
 import {resolveReference} from '../util/ast';
 import {builtInTagClassMap} from '../util/tag-names';
@@ -99,13 +99,7 @@ const rule: Rule.RuleModule = {
     const source = context.getSourceCode();
     const elementClasses = new Set<ESTree.Class>();
     const userAllowedSuperNames = context.options[0]?.allowedSuperNames ?? [];
-    const elementBaseClasses = ['HTMLElement'];
-
-    if (Array.isArray(context.settings.wc?.elementBaseClasses)) {
-      elementBaseClasses.push(
-        ...(context.settings.wc.elementBaseClasses as string[])
-      );
-    }
+    const elementBaseClasses = getElementBaseClasses(context);
 
     return {
       'ClassExpression,ClassDeclaration': (node: ESTree.Class): void => {

--- a/src/test/util_test.ts
+++ b/src/test/util_test.ts
@@ -64,7 +64,7 @@ describe('util', () => {
   });
 
   describe('getElementBaseClasses', () => {
-    it('should default to HTMLElement, LitElement', () => {
+    it('should default to HTMLElement', () => {
       expect(util.getElementBaseClasses(mockContext)).to.deep.equal([
         'HTMLElement'
       ]);

--- a/src/test/util_test.ts
+++ b/src/test/util_test.ts
@@ -13,11 +13,15 @@ const parseExpr = <T extends ESTree.Node = ESTree.Node>(expr: string): T => {
   return (parsed as ESTree.Program).body[0] as T;
 };
 
-const mockContext = {
-  settings: {}
-} as unknown as Rule.RuleContext;
-
 describe('util', () => {
+  let mockContext: Rule.RuleContext;
+
+  beforeEach(() => {
+    mockContext = {
+      settings: {}
+    } as unknown as Rule.RuleContext;
+  });
+
   describe('isCustomElement', () => {
     it('should parse direct sub classes of HTMLElement', () => {
       const doc = parseExpr<ESTree.Class>(`class Foo extends HTMLElement {}`);
@@ -56,6 +60,26 @@ describe('util', () => {
 
       doc = parseExpr<ESTree.Class>(`class Foo {}`);
       expect(util.isCustomElement(mockContext, doc)).to.equal(false);
+    });
+  });
+
+  describe('getElementBaseClasses', () => {
+    it('should default to HTMLElement, LitElement', () => {
+      expect(util.getElementBaseClasses(mockContext)).to.deep.equal([
+        'HTMLElement'
+      ]);
+    });
+
+    it('should respect user settings', () => {
+      const result = util.getElementBaseClasses({
+        ...mockContext,
+        settings: {
+          wc: {
+            elementBaseClasses: ['FooElement']
+          }
+        }
+      });
+      expect(result).to.deep.equal(['HTMLElement', 'FooElement']);
     });
   });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,6 +28,10 @@ export function isCustomElementDecorator(node: DecoratorNode): boolean {
   );
 }
 
+const knownModuleBaseClasses = new Map<string, Set<string>>([
+  ['lit', new Set(['LitElement'])]
+]);
+
 /**
  * Retrieves the configured element base class list
  *
@@ -36,6 +40,19 @@ export function isCustomElementDecorator(node: DecoratorNode): boolean {
  */
 export function getElementBaseClasses(context: Rule.RuleContext): string[] {
   const bases = new Set<string>(['HTMLElement']);
+
+  for (const [moduleName, moduleClasses] of knownModuleBaseClasses) {
+    try {
+      require.resolve(moduleName);
+
+      for (const moduleClass of moduleClasses) {
+        bases.add(moduleClass);
+      }
+    } catch (_err) {
+      // do nothing, lit didn't exist
+    }
+  }
+
   if (Array.isArray(context.settings.wc?.elementBaseClasses)) {
     const configuredBases = context.settings.wc.elementBaseClasses as string[];
     for (const base of configuredBases) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,6 +29,24 @@ export function isCustomElementDecorator(node: DecoratorNode): boolean {
 }
 
 /**
+ * Retrieves the configured element base class list
+ *
+ * @param {Rule.RuleContext} context ESLint rule context
+ * @return {string[]}
+ */
+export function getElementBaseClasses(context: Rule.RuleContext): string[] {
+  const bases = new Set<string>(['HTMLElement']);
+  if (Array.isArray(context.settings.wc?.elementBaseClasses)) {
+    const configuredBases = context.settings.wc.elementBaseClasses as string[];
+    for (const base of configuredBases) {
+      bases.add(base);
+    }
+  }
+
+  return [...bases];
+}
+
+/**
  * Determines if a node is an element class or not.
  *
  * @param {Rule.RuleContext} context ESLint rule context
@@ -42,17 +60,11 @@ export function isCustomElement(
   jsdoc?: ESTree.Comment | null
 ): boolean {
   const asDecorated = node as WithDecorators<ESTree.Node>;
-  const customElementBases: string[] = ['HTMLElement'];
+  const customElementBases = getElementBaseClasses(context);
   const cached = customElementsCache.get(node);
 
   if (cached !== undefined) {
     return cached;
-  }
-
-  if (Array.isArray(context.settings.wc?.elementBaseClasses)) {
-    customElementBases.push(
-      ...(context.settings.wc.elementBaseClasses as string[])
-    );
   }
 
   if (


### PR DESCRIPTION
Introducing the `invalid-extends` rule into the best practice config resulted in a larger breaking change than expected: LitElement repos fail to lint without introducing an `elementBaseClasses` setting.

Since a large chunk of our consumers are lit users, it makes sense to add it to the recommended config so it doesn't need configuring individually.