### PR TITLE
fix(file-name-matches-element): respect 'none' case type

### DIFF
--- a/src/test/rules/file-name-matches-element_test.ts
+++ b/src/test/rules/file-name-matches-element_test.ts
@@ -196,6 +196,15 @@ ruleTester.run('file-name-matches-element', rule, {
           suffix: 'Bar'
         }
       ]
+    },
+    {
+      code: 'class SomeElement extends HTMLElement {}',
+      filename: 'SomeElement.js',
+      options: [
+        {
+          transform: 'none'
+        }
+      ]
     }
   ],
 

--- a/src/util/text.ts
+++ b/src/util/text.ts
@@ -54,7 +54,7 @@ export function toCamelCase(str: string): string {
  */
 export function toCaseByType(
   str: string,
-  type: 'kebab' | 'camel' | 'snake' | 'pascal'
+  type: 'kebab' | 'camel' | 'snake' | 'pascal' | 'none'
 ): string {
   switch (type) {
     case 'kebab':
@@ -65,5 +65,7 @@ export function toCaseByType(
       return toSnakeCase(str);
     case 'pascal':
       return toPascalCase(str);
+    case 'none':
+      return str;
   }
 }


### PR DESCRIPTION
We forgot to implement `none` as a case type/transform in the file-name-matches-element rule. It is basically a pass-through transform, i.e. the name of the class should be exactly the name of the file.

Fixes #126