### PR TITLE
Fix compatibility issue with ESLint v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "js-levenshtein-esm": "^1.2.0"
   },
   "peerDependencies": {
-    "eslint": ">=5"
+    "eslint": ">=8.40.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",

--- a/src/rules/attach-shadow-constructor.ts
+++ b/src/rules/attach-shadow-constructor.ts
@@ -27,7 +27,7 @@ const rule: Rule.RuleModule = {
     // variables should be defined here
     let insideNonConstructor = false;
     let insideElement = false;
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/define-tag-after-class-definition.ts
+++ b/src/rules/define-tag-after-class-definition.ts
@@ -35,7 +35,7 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     const seenClasses = new Set<ESTree.Node>();
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/expose-class-on-global.ts
+++ b/src/rules/expose-class-on-global.ts
@@ -33,7 +33,7 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     const seenClasses = new Set<ESTree.Node>();
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/file-name-matches-element.ts
+++ b/src/rules/file-name-matches-element.ts
@@ -116,14 +116,14 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
     const options = context.options?.[0] ?? {};
     const userSuffixes = coerceArray(options.suffix ?? []);
     const userPrefixes = coerceArray(options.prefix ?? []);
     const transforms = coerceArray(options.transform ?? ['kebab', 'camel']);
     const matchDirectory = options.matchDirectory === true;
 
-    const filename = context.getFilename();
+    const filename = context.filename;
 
     // We don't want to match stdin and what not
     if (!filename || filename === '<input>' || filename === '<text>') {

--- a/src/rules/guard-super-call.ts
+++ b/src/rules/guard-super-call.ts
@@ -27,7 +27,7 @@ const rule: Rule.RuleModule = {
   create(context): Rule.RuleListener {
     let insideNonNativeElement = false;
     let errNode = null;
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     const nativeHooks = [
       'connectedCallback',

--- a/src/rules/max-elements-per-file.ts
+++ b/src/rules/max-elements-per-file.ts
@@ -36,7 +36,7 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     // variables should be defined here
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
     const maxElements = context.options[0]?.max ?? 1;
     let elementCount = 0;
 

--- a/src/rules/no-child-traversal-in-attributechangedcallback.ts
+++ b/src/rules/no-child-traversal-in-attributechangedcallback.ts
@@ -40,7 +40,7 @@ const rule: Rule.RuleModule = {
     // variables should be defined here
     let insideCallback = false;
     let insideElement = false;
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/no-child-traversal-in-connectedcallback.ts
+++ b/src/rules/no-child-traversal-in-connectedcallback.ts
@@ -136,7 +136,7 @@ const rule: Rule.RuleModule = {
           return;
         }
 
-        const scope = context.getScope();
+        const scope = context.sourceCode.getScope(node);
         const name = node.property.name;
 
         if (isAllowedScope(scope)) {

--- a/src/rules/no-child-traversal-in-connectedcallback.ts
+++ b/src/rules/no-child-traversal-in-connectedcallback.ts
@@ -85,7 +85,7 @@ const rule: Rule.RuleModule = {
     // variables should be defined here
     let insideCallback = false;
     let insideElement = false;
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/no-constructor-attributes.ts
+++ b/src/rules/no-constructor-attributes.ts
@@ -72,7 +72,7 @@ const rule: Rule.RuleModule = {
       'title',
       'translate'
     ];
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/no-constructor-params.ts
+++ b/src/rules/no-constructor-params.ts
@@ -29,7 +29,7 @@ const rule: Rule.RuleModule = {
       'ClassBody > MethodDefinition[kind="constructor"]' +
       '[value.params.length > 0]';
     let insideElement = false;
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/no-constructor.ts
+++ b/src/rules/no-constructor.ts
@@ -28,7 +28,7 @@ const rule: Rule.RuleModule = {
   create(context): Rule.RuleListener {
     // variables should be defined here
     let insideElement = false;
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/no-customized-built-in-elements.ts
+++ b/src/rules/no-customized-built-in-elements.ts
@@ -28,7 +28,7 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     // variables should be defined here
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/no-exports-with-element.ts
+++ b/src/rules/no-exports-with-element.ts
@@ -30,7 +30,7 @@ const rule: Rule.RuleModule = {
     const seenClasses = new Set<ESTree.Node>();
     const exportedNodes = new Set<ESTree.Node>();
     let hasElement = false;
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     return {
       'ClassDeclaration,ClassExpression': (node: ESTree.Class): void => {

--- a/src/rules/no-invalid-extends.ts
+++ b/src/rules/no-invalid-extends.ts
@@ -96,7 +96,7 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
     const elementClasses = new Set<ESTree.Class>();
     const userAllowedSuperNames = context.options[0]?.allowedSuperNames ?? [];
     const elementBaseClasses = getElementBaseClasses(context);

--- a/src/rules/no-method-prefixed-with-on.ts
+++ b/src/rules/no-method-prefixed-with-on.ts
@@ -29,7 +29,7 @@ const rule: Rule.RuleModule = {
   create(context): Rule.RuleListener {
     // variables should be defined here
     let insideElement = false;
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers
@@ -52,7 +52,7 @@ const rule: Rule.RuleModule = {
         if (insideElement) {
           const name = getMethodName(node);
 
-          if (name && name.startsWith('on')) {
+          if (name?.startsWith('on')) {
             context.report({
               node,
               messageId: 'noPrefix'

--- a/src/rules/no-self-class.ts
+++ b/src/rules/no-self-class.ts
@@ -28,7 +28,7 @@ const rule: Rule.RuleModule = {
     // variables should be defined here
     let insideElement = false;
     const bannedClassListMethods = ['add', 'remove', 'toggle', 'replace'];
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/no-typos.ts
+++ b/src/rules/no-typos.ts
@@ -29,7 +29,7 @@ const rule: Rule.RuleModule = {
   create(context): Rule.RuleListener {
     // variables should be defined here
     let insideElement = false;
-    const source = context.getSourceCode();
+    const source = context.sourceCode;
     const lifecycleMethods = [
       'connectedCallback',
       'disconnectedCallback',

--- a/src/rules/require-listener-teardown.ts
+++ b/src/rules/require-listener-teardown.ts
@@ -60,7 +60,7 @@ const rule: Rule.RuleModule = {
     // Helpers
     //----------------------------------------------------------------------
     const shouldTrackListener = (node: ESTree.MemberExpression): boolean => {
-      const source = context.getSourceCode();
+      const source = context.sourceCode;
 
       const text = source.getText(node.object);
 
@@ -82,7 +82,7 @@ const rule: Rule.RuleModule = {
         node.callee.type === 'MemberExpression' &&
         shouldTrackListener(node.callee)
       ) {
-        const source = context.getSourceCode();
+        const source = context.sourceCode;
         const calleeText = source.getText(node.callee.object);
         const [arg0, arg1] = node.arguments;
 
@@ -104,7 +104,7 @@ const rule: Rule.RuleModule = {
         node.callee.type === 'MemberExpression' &&
         shouldTrackListener(node.callee)
       ) {
-        const source = context.getSourceCode();
+        const source = context.sourceCode;
         const calleeText = source.getText(node.callee.object);
         const [arg0, arg1] = node.arguments;
 

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -35,8 +35,7 @@ export function resolveReference(
     return node;
   }
 
-  const ref = context
-    .getSourceCode()
+  const ref = context.sourceCode
     .getScope(node)
     .references.find((r) => r.identifier.name === node.name);
 


### PR DESCRIPTION
The `context.getScope()` function, removed in ESLint v9, was used in `src/rules/no-child-traversal-in-connectedcallback.ts`, causing an error when the rule was executed in ESLint v9.
This PR migrates the relevant part to the new `context.sourceCode.getScope(node)` and migrates other deprecated APIs such as `getSourceCode()` to the new API added in ESLint v8.40.0.