### PR TITLE
Fix flat config instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Or if you're using ESLint flat configs, add this to your `eslint.config.js`:
 import {configs} from 'eslint-plugin-wc';
 
 export default [
-  configs.recommended,
+  configs['flat/recommended'],
 
   // or if you want to specify `files`, or other options
   {
-    ...configs.recommended,
+    ...configs['flat/recommended'],
     files: ['test/**/*.js']
   }
 ];


### PR DESCRIPTION
The config instructions for ESLint flat configuration didn't work for me. I received this error message:

```
Oops! Something went wrong! :(                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                    
ESLint: 9.12.0                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                    
A config object has a "plugins" key defined as an array of strings.                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                    
Flat config requires "plugins" to be an object in this form:                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                    
    {                                                                                                                                                                                                                                                                               
        plugins: {                                                                                                                                                                                                                                                                  
            wc: pluginObject                                                                                                                                                                                                                                                        
        }                                                                                                                                                                                                                                                                           
    }                                                                                                                                                                                                                                                                               
```

With this change everything works fine.