### PR TITLE
Update `guard-define-call` rule for eslint 9 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "^5.1.6"
       },
       "peerDependencies": {
-        "eslint": ">=5"
+        "eslint": ">=8.40.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/src/rules/guard-define-call.ts
+++ b/src/rules/guard-define-call.ts
@@ -27,7 +27,7 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     const definedCustomElements = new Set<string>();
-
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------
@@ -63,8 +63,9 @@ const rule: Rule.RuleModule = {
         }
 
         if (isGetCall(node) && tagName) {
-          // TODO (43081j): use source.getAncestors(node)
-          const ancestors = context.getAncestors();
+          const ancestors = sourceCode.getAncestors
+            ? sourceCode.getAncestors(node)
+            : context.getAncestors();
           const isInsideIfStatement = ancestors.some(
             (ancestor): boolean =>
               ancestor.type === 'IfStatement' &&

--- a/src/rules/guard-define-call.ts
+++ b/src/rules/guard-define-call.ts
@@ -64,7 +64,6 @@ const rule: Rule.RuleModule = {
 
         if (isGetCall(node) && tagName) {
           const ancestors = source.getAncestors(node);
-            ? sourceCode.getAncestors(node)
             : context.getAncestors();
           const isInsideIfStatement = ancestors.some(
             (ancestor): boolean =>

--- a/src/rules/guard-define-call.ts
+++ b/src/rules/guard-define-call.ts
@@ -27,7 +27,7 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     const definedCustomElements = new Set<string>();
-    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const source = context.sourceCode;
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------

--- a/src/rules/guard-define-call.ts
+++ b/src/rules/guard-define-call.ts
@@ -63,7 +63,7 @@ const rule: Rule.RuleModule = {
         }
 
         if (isGetCall(node) && tagName) {
-          const ancestors = sourceCode.getAncestors
+          const ancestors = source.getAncestors(node);
             ? sourceCode.getAncestors(node)
             : context.getAncestors();
           const isInsideIfStatement = ancestors.some(

--- a/src/rules/guard-define-call.ts
+++ b/src/rules/guard-define-call.ts
@@ -64,7 +64,6 @@ const rule: Rule.RuleModule = {
 
         if (isGetCall(node) && tagName) {
           const ancestors = source.getAncestors(node);
-            : context.getAncestors();
           const isInsideIfStatement = ancestors.some(
             (ancestor): boolean =>
               ancestor.type === 'IfStatement' &&


### PR DESCRIPTION
I was running into some compatibility issues with ESLint 9 for the `guard-define-call` rule:

```
ESLint: 9.20.1

TypeError: context.getAncestors is not a function
Occurred while linting
Rule: "wc/guard-define-call"
```

Tested out the rule update: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context.getancestors() and this looks to fix the issue.