### PR TITLE
fix: export a default for now

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,3 +59,7 @@ export const configs = {
   'flat/recommended': configRecommended(plugin),
   'flat/best-practice': configBestPractice(plugin)
 };
+
+plugin.configs = configs;
+
+export default plugin;


### PR DESCRIPTION
ESLint still expects it in some CLI situations.