### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/src/rules/file-name-matches-element.ts
+++ b/src/rules/file-name-matches-element.ts
@@ -110,7 +110,8 @@ const rule: Rule.RuleModule = {
           matchDirectory: {
             type: 'boolean'
           }
-        }
+        },
+        additionalProperties: false
       }
     ]
   },

--- a/src/rules/max-elements-per-file.ts
+++ b/src/rules/max-elements-per-file.ts
@@ -29,7 +29,8 @@ const rule: Rule.RuleModule = {
             type: 'integer',
             minimum: 1
           }
-        }
+        },
+        additionalProperties: false
       }
     ]
   },


### PR DESCRIPTION
Some rules, for example [file-name-matches-element](https://github.com/43081j/eslint-plugin-wc/blob/12b936694519efa4bbc6d9232f33ebd238392a01/src/rules/file-name-matches-element.ts#L67) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.