### PR TITLE
fix: ignore listeners with signals

### DIFF
--- a/src/rules/require-listener-teardown.ts
+++ b/src/rules/require-listener-teardown.ts
@@ -73,6 +73,13 @@ const rule: Rule.RuleModule = {
         node.callee.type === 'MemberExpression' &&
         node.callee.property.type === 'Identifier' &&
         node.callee.property.name === 'bind');
+    const hasSignal = (node: ESTree.ObjectExpression): boolean =>
+      node.properties.some(
+        (prop) =>
+          prop.type === 'Property' &&
+          ((prop.key.type === 'Identifier' && prop.key.name === 'signal') ||
+            (prop.key.type === 'Literal' && prop.key.value === 'signal'))
+      );
 
     //----------------------------------------------------------------------
     // Public
@@ -84,7 +91,11 @@ const rule: Rule.RuleModule = {
       ) {
         const source = context.sourceCode;
         const calleeText = source.getText(node.callee.object);
-        const [arg0, arg1] = node.arguments;
+        const [arg0, arg1, arg3] = node.arguments;
+
+        if (arg3 && arg3.type === 'ObjectExpression' && hasSignal(arg3)) {
+          return;
+        }
 
         if (isInlineFunction(arg1)) {
           context.report({

--- a/src/test/rules/require-listener-teardown_test.ts
+++ b/src/test/rules/require-listener-teardown_test.ts
@@ -78,6 +78,34 @@ ruleTester.run('require-listener-teardown', rule, {
           hosts: ['window', 'document']
         }
       ]
+    },
+    {
+      code: `class Foo extends HTMLElement {
+      constructor() {
+        this.controller = new AbortController();
+        this.signal = this.controller.signal;
+      }
+      connectedCallback() {
+        this.addEventListener('x', console.log, { signal: this.signal });
+      }
+      disconnectedCallback() {
+        this.controller.abort();
+      }
+    }`
+    },
+    {
+      code: `class Foo extends HTMLElement {
+      constructor() {
+        this.controller = new AbortController();
+      }
+      connectedCallback() {
+        const {signal} = this.controller;
+        this.addEventListener('x', console.log, { signal });
+      }
+      disconnectedCallback() {
+        this.controller.abort();
+      }
+    }`
     }
   ],
 


### PR DESCRIPTION
We currently report listeners with a `signal` as not being torn down if
we don't later use `removeEventListener`.

Since there's too many cases to check, this change just blanket allows
all listeners to have no teardown which have a `signal`.

Fixes #148
