### PR TITLE
feat: add no-unused-scoped-elements rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 - [wc/no-customized-built-in-elements](docs/rules/no-customized-built-in-elements.md)
 - [wc/no-invalid-extends](docs/rules/no-invalid-extends.md)
 - [wc/no-typos](docs/rules/no-typos.md)
+- [wc/no-unused-scoped-elements](docs/rules/no-unused-scoped-elements.md)
 - [wc/require-listener-teardown](docs/rules/require-listener-teardown.md)
 
 ### Preference/convention

--- a/docs/rules/no-unused-scoped-elements.md
+++ b/docs/rules/no-unused-scoped-elements.md
@@ -1,0 +1,88 @@
+# Disallows unused entries in static `scopedElements` (no-unused-scoped-elements)
+
+When using scoped custom element registries, every tag listed in
+`scopedElements` should be used in the component template. Unused mappings add
+noise and make maintenance harder.
+
+## Rule Details
+
+This rule reports string-literal tags declared in static `scopedElements` when
+they are not used in template-like class method bodies.
+
+It supports both:
+
+* `static scopedElements = { ... }`
+* `static get scopedElements() { return { ... }; }`
+
+The following patterns are considered warnings:
+
+```ts
+class MyPage {
+  static scopedElements = {
+    'unused-tag': UnusedTag
+  };
+
+  render() {
+    return html`<div></div>`;
+  }
+}
+```
+
+```ts
+class MyPage {
+  static get scopedElements() {
+    return {
+      'unused-tag': UnusedTag
+    };
+  }
+
+  render() {
+    return html`<div></div>`;
+  }
+}
+```
+
+The following patterns are not warnings:
+
+```ts
+class MyPage {
+  static scopedElements = {
+    'my-tag': MyTag
+  };
+
+  render() {
+    return html`<my-tag></my-tag>`;
+  }
+}
+```
+
+```ts
+class MyPage {
+  static get scopedElements() {
+    return {
+      'my-tag': MyTag
+    };
+  }
+
+  renderHelper() {
+    return html`<my-tag></my-tag>`;
+  }
+
+  render() {
+    return this.renderHelper();
+  }
+}
+```
+
+## Limitations
+
+This rule intentionally focuses on static analysis of straightforward patterns:
+
+* Only static `scopedElements` defined as an object literal (or returned object literal) are checked.
+* Dynamic/computed values (for example function calls or computed keys) are ignored.
+* Usage detection is text-based over class method bodies, so highly dynamic rendering patterns may not be detected.
+
+## When Not To Use It
+
+If your `scopedElements` declarations are intentionally broad or mostly dynamic
+and you do not want static usage checks, you should not use this rule.

--- a/src/configs/best-practice.ts
+++ b/src/configs/best-practice.ts
@@ -16,6 +16,7 @@ export const configFactory = (plugin: ESLint.Plugin): Linter.FlatConfig => {
       'wc/no-customized-built-in-elements': 'error',
       'wc/no-invalid-extends': 'error',
       'wc/no-typos': 'error',
+      'wc/no-unused-scoped-elements': 'error',
       'wc/require-listener-teardown': 'error'
     }
   };

--- a/src/configs/legacy-best-practice.ts
+++ b/src/configs/legacy-best-practice.ts
@@ -14,6 +14,7 @@ export const config: ESLint.ConfigData = {
     'wc/no-customized-built-in-elements': 'error',
     'wc/no-invalid-extends': 'error',
     'wc/no-typos': 'error',
+    'wc/no-unused-scoped-elements': 'error',
     'wc/require-listener-teardown': 'error'
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import noInvalidExtends from './rules/no-invalid-extends.js';
 import noOnPrefix from './rules/no-method-prefixed-with-on.js';
 import noSelfClass from './rules/no-self-class.js';
 import noTypos from './rules/no-typos.js';
+import noUnusedScopedElements from './rules/no-unused-scoped-elements.js';
 import {configFactory as configRecommended} from './configs/recommended.js';
 import {configFactory as configBestPractice} from './configs/best-practice.js';
 import {config as configLegacyRecommended} from './configs/legacy-recommended.js';
@@ -47,6 +48,7 @@ export const rules = {
   'no-method-prefixed-with-on': noOnPrefix,
   'no-self-class': noSelfClass,
   'no-typos': noTypos,
+  'no-unused-scoped-elements': noUnusedScopedElements,
   'require-listener-teardown': requireListenerTeardown,
   'tag-name-matches-class': tagMatchesClass
 };

--- a/src/rules/no-unused-scoped-elements.ts
+++ b/src/rules/no-unused-scoped-elements.ts
@@ -1,0 +1,129 @@
+/**
+ * @fileoverview Disallows unused entries in static scopedElements
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+
+function filterLiteralKeys(
+  properties: Array<ESTree.Property | ESTree.SpreadElement>
+): string[] {
+  return properties.flatMap((prop) => {
+    if (prop.type !== 'Property' || prop.key.type !== 'Literal') {
+      return [];
+    }
+    return typeof prop.key.value === 'string' ? [prop.key.value] : [];
+  });
+}
+
+function extractTagsFromNode(
+  valueNode: ESTree.Expression | ESTree.PrivateIdentifier | null | undefined
+): string[] {
+  if (!valueNode) {
+    return [];
+  }
+
+  switch (valueNode.type) {
+    case 'ObjectExpression':
+      return filterLiteralKeys(valueNode.properties);
+    case 'FunctionExpression': {
+      const returnStatement = valueNode.body.body.find(
+        (stmt): stmt is ESTree.ReturnStatement =>
+          stmt.type === 'ReturnStatement'
+      );
+      const returnedValue = returnStatement?.argument;
+
+      if (returnedValue?.type === 'ObjectExpression') {
+        return filterLiteralKeys(returnedValue.properties);
+      }
+
+      return [];
+    }
+    default:
+      return [];
+  }
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//-----
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Detect unused static scopedElements in LitElement.',
+      url: 'https://github.com/43081j/eslint-plugin-wc/blob/master/docs/rules/no-unused-scoped-elements.md'
+    },
+    schema: [],
+    messages: {
+      unusedScopedElement:
+        "Class {{className}} has unused scoped element '{{tag}}'."
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    const source = context.sourceCode;
+
+    return {
+      ClassDeclaration: (node: ESTree.ClassDeclaration): void => {
+        const classBody = node.body.body;
+        const scopedElementsProp = classBody.find(
+          (prop): prop is ESTree.MethodDefinition | ESTree.PropertyDefinition =>
+            (prop.type === 'PropertyDefinition' ||
+              prop.type === 'MethodDefinition') &&
+            prop.static === true &&
+            prop.key.type === 'Identifier' &&
+            prop.key.name === 'scopedElements'
+        );
+
+        if (!scopedElementsProp) {
+          return;
+        }
+
+        const tags = extractTagsFromNode(scopedElementsProp.value);
+
+        const templateStr = classBody
+          .flatMap((field) => {
+            if (
+              (field.type !== 'MethodDefinition' &&
+                field.type !== 'PropertyDefinition') ||
+              !field.value
+            ) {
+              return [];
+            }
+
+            if (
+              (field.value.type === 'FunctionExpression' ||
+                field.value.type === 'ArrowFunctionExpression') &&
+              field.value.body.type === 'BlockStatement'
+            ) {
+              return [source.getText(field.value.body)];
+            }
+
+            return [];
+          })
+          .join('');
+
+        const className = node.id?.name ?? 'AnonymousClass';
+
+        tags.forEach((tag) => {
+          const tagUsageRegex = new RegExp(`<${tag}[\\s>/]`, 'i');
+
+          if (!tagUsageRegex.test(templateStr)) {
+            context.report({
+              node: node.id ?? node,
+              messageId: 'unusedScopedElement',
+              data: {
+                className,
+                tag
+              }
+            });
+          }
+        });
+      }
+    };
+  }
+};
+
+export default rule;

--- a/src/test/rules/no-unused-scoped-elements_test.ts
+++ b/src/test/rules/no-unused-scoped-elements_test.ts
@@ -1,0 +1,282 @@
+/**
+ * @fileoverview Disallows unused entries in static scopedElements
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule from '../../rules/no-unused-scoped-elements.js';
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      sourceType: 'module',
+      ecmaVersion: 2022
+    }
+  }
+});
+
+const scopedElementsProperty = (tag: string): string => `
+  static scopedElements = {
+    '${tag}': MyTag
+  };
+`;
+
+const scopedElementsGetter = (tag: string): string => `
+  static get scopedElements() {
+    return {
+      '${tag}': MyTag
+    };
+  }
+`;
+
+const renderMethod = (template: string): string => `
+  render() {
+    return html\`${template}\`;
+  }
+`;
+
+ruleTester.run('no-unused-scoped-elements', rule, {
+  valid: [
+    {
+      code: `
+        class MyPage {
+          ${scopedElementsProperty('my-tag')}
+          ${renderMethod('<my-tag></my-tag>')}
+        }
+      `
+    },
+    {
+      code: `
+        class MyPage {
+          ${scopedElementsGetter('my-tag')}
+          ${renderMethod('<my-tag></my-tag>')}
+        }
+      `
+    },
+    {
+      code: `
+        class MyPage {
+          ${scopedElementsProperty('my-tag')}
+
+          renderHelper() {
+            return html\`<my-tag></my-tag>\`;
+          }
+
+          render() {
+            return this.renderHelper();
+          }
+        }
+      `
+    },
+    {
+      code: `
+        class MyPage {
+          ${scopedElementsGetter('my-tag')}
+
+          renderHelper() {
+            return html\`<my-tag></my-tag>\`;
+          }
+
+          render() {
+            return this.renderHelper();
+          }
+        }
+      `
+    },
+    {
+      code: `
+        class MyPage {
+          static scopedElements = {
+            myTag: MyTag
+          };
+
+          render() {
+            return html\`<my-tag></my-tag>\`;
+          }
+        }
+      `
+    },
+    {
+      code: `
+        class MyPage {
+          static get scopedElements() {
+            return getScoped();
+          }
+
+          render() {
+            return html\`<div></div>\`;
+          }
+        }
+      `
+    },
+    {
+      code: `
+        class MyPage {
+          static scopedElements = {
+            'my-tag': MyTag,
+            ...super.scopedElements
+          };
+
+          render() {
+            return html\`<my-tag></my-tag>\`;
+          }
+        }
+      `
+    },
+    {
+      code: `
+        class MyPage {
+          static get scopedElements() {
+            return {
+              'my-tag': MyTag,
+              ...super.scopedElements
+            };
+          }
+
+          render() {
+            return html\`<my-tag></my-tag>\`;
+          }
+        }
+      `
+    },
+    {
+      code: `
+        class MyPage {
+          scopedElements = {
+            myTag: MyTag
+          };
+
+          render() {
+            return html\`<div></div>\`;
+          }
+        }
+      `
+    },
+    {
+      code: `
+        class MyPage {
+          static scopedElements = null;
+
+          render() {
+            return html\`<div></div>\`;
+          }
+        }
+      `
+    },
+    {
+      code: `
+        class MyPage {
+          static scopedElements = {};
+
+          render() {
+            return html\`<div></div>\`;
+          }
+        }
+      `
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+        class MyPage {
+          static scopedElements = {
+            'unused-tag': UnusedTag
+          };
+
+          render() {
+            return html\`<div></div>\`;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unusedScopedElement',
+          data: {
+            className: 'MyPage',
+            tag: 'unused-tag'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        class MyPage {
+          static get scopedElements() {
+            return {
+              'unused-tag': UnusedTag
+            };
+          }
+
+          render() {
+            return html\`<div></div>\`;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unusedScopedElement',
+          data: {
+            className: 'MyPage',
+            tag: 'unused-tag'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        class MyPage {
+          static scopedElements = {
+            'unused-tag': UnusedTag,
+            ...super.scopedElements
+          };
+
+          render() {
+            return html\`<div></div>\`;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unusedScopedElement',
+          data: {
+            className: 'MyPage',
+            tag: 'unused-tag'
+          }
+        }
+      ]
+    },
+    {
+      code: `
+        class MyPage {
+          static get scopedElements() {
+            return {
+              'unused-tag': UnusedTag,
+              ...super.scopedElements
+            };
+          }
+
+          render() {
+            return html\`<div></div>\`;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unusedScopedElement',
+          data: {
+            className: 'MyPage',
+            tag: 'unused-tag'
+          }
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
## Summary

I’d like to contribute a new rule idea to `eslint-plugin-wc`: **`no-unused-scoped-elements`**.

The rule helps catch entries in `scopedElements` that are declared but never used in the component’s templates/method bodies. This keeps scoped registries cleaner and reduces stale mappings over time.

## What this PR adds

- New rule implementation: `no-unused-scoped-elements`
- Test coverage for valid/invalid and edge-case scenarios
- Rule export in the plugin index
- Rule documentation in `docs/rules/no-unused-scoped-elements.md`
- Rule listed in README supported rules
- Rule included in `best-practice` configs (flat + legacy)
- Changelog entry under `Unreleased`

## Why this can be useful

In component codebases that use `scopedElements`, mappings often evolve as templates change. It’s easy for unused registrations to remain in place, which adds noise and can make maintenance harder. This rule provides a lightweight check to surface those unused entries early.

## Current scope / limitations

This initial version intentionally focuses on static analysis of straightforward patterns:

- Supports:
  - `static scopedElements = { ... }`
  - `static get scopedElements() { return { ... }; }`
- Only string-literal tag keys are checked
- Dynamic/computed patterns are ignored
- Usage detection is text-based over class method bodies

## Notes

I’m happy to adjust naming, severity/config placement, or detection behavior based on maintainer feedback. I mainly wanted to contribute the idea and a working baseline implementation for discussion.